### PR TITLE
Georeference Coordinate Field Names

### DIFF
--- a/cdr_schemas/georeference.py
+++ b/cdr_schemas/georeference.py
@@ -7,23 +7,41 @@ from cdr_schemas.area_extraction import Area_Extraction
 
 class Geom_Point(BaseModel):
     """
-    Geometry Point:
-    Point geometry in world coordinates (longitude, latitude).
+    Geometry Point
     """
 
-    latitude: Optional[Union[float, int]]
-    longitude: Optional[Union[float, int]]
+    latitude: Optional[Union[float, int]] = Field(
+        ...,
+        description="""
+            The latitude value for the world coordinate.
+        """,
+    )
+    longitude: Optional[Union[float, int]] = Field(
+        ...,
+        description="""
+            The longitude value for the world coordinate.
+        """,
+    )
     type: GeomType = GeomType.Point
 
 
 class Pixel_Point(BaseModel):
     """
-    Pixel point.
-    Point geometry in pixel coordinates (columns from left, row from bottom).
+    Pixel point
     """
 
-    rows_from_top: Union[float, int]
-    columns_from_left: Union[float, int]
+    rows_from_top: Union[float, int] = Field(
+        ...,
+        description="""
+            The number of rows from the top, equivalent to the usual y value in images.
+        """,
+    )
+    columns_from_left: Union[float, int] = Field(
+        ...,
+        description="""
+            The number of columns from the left, equivalent to the usual x value in images.
+        """,
+    )
     type: GeomType = GeomType.Point
 
 

--- a/cdr_schemas/georeference.py
+++ b/cdr_schemas/georeference.py
@@ -22,8 +22,8 @@ class Pixel_Point(BaseModel):
     Point geometry in pixel coordinates (columns from left, row from bottom).
     """
 
-    rows_from_left: Union[float, int]
-    columns_from_top: Union[float, int]
+    rows_from_top: Union[float, int]
+    columns_from_left: Union[float, int]
     type: GeomType = GeomType.Point
 
 

--- a/cdr_schemas/georeference.py
+++ b/cdr_schemas/georeference.py
@@ -11,7 +11,8 @@ class Geom_Point(BaseModel):
     Point geometry in world coordinates (longitude, latitude).
     """
 
-    coordinates: List[Optional[Union[float, int]]]
+    latitude: Optional[Union[float, int]]
+    longitude: Optional[Union[float, int]]
     type: GeomType = GeomType.Point
 
 
@@ -21,7 +22,8 @@ class Pixel_Point(BaseModel):
     Point geometry in pixel coordinates (columns from left, row from bottom).
     """
 
-    coordinates: List[Union[float, int]]
+    rows_from_left: Union[float, int]
+    columns_from_top: Union[float, int]
     type: GeomType = GeomType.Point
 
 


### PR DESCRIPTION
Switched from coordinates being captured by lists to using named fields. Having named fields reduces the chance of switching coordinates around due to lists being in arbitrary order.