### PR TITLE
updates on line/polygon/point features

### DIFF
--- a/cdr_schemas/line_features.py
+++ b/cdr_schemas/line_features.py
@@ -5,9 +5,9 @@ from enum import Enum
 
 
 class DashType(str, Enum):
-    Point = "solid"
-    LineString = "dash"
-    Polygon = "dotted"
+    solid = "solid"
+    dash = "dash"
+    dotted = "dotted"
 
 
 class Line(BaseModel):
@@ -34,6 +34,10 @@ class LineProperty(BaseModel):
     )
 
     model_config = ConfigDict(protected_namespaces=())
+    dash_pattern: Optional[DashType] = Field(
+        default=None, description="values = {solid, dash, dotted}"
+    )
+    symbol: Optional[str]
 
 
 class LineFeature(BaseModel):
@@ -42,6 +46,10 @@ class LineFeature(BaseModel):
     """
 
     type: str = GeoJsonType.Feature
+    id: str = Field(
+                    description="""Each line geometry has a unique id.
+                    The ids are used to link the line geometries is px-coord and geo-coord."""
+               )
     geometry: Line
     properties: LineProperty
 
@@ -61,12 +69,12 @@ class LineLegendAndFeaturesResult(BaseModel):
     """
 
     id: str = Field(description="your internal id")
-    name: Optional[str]
-    dash_pattern: Optional[DashType] = Field(
-        default=None, description="values = {solid, dash, dotted}"
+    map_cog_id: str = Field(
+                    description="""map_cog_id is used to link the extracted lines and thecorresponding geologic map"""
     )
+    crs: str = Field(description="values={CRITICALMAAS:pixel, EPSG:*}")
+    name: Optional[str]
     description: Optional[str]
-    symbol: Optional[str]
     legend_bbox: Optional[List[Union[float, int]]] = Field(
         description="""The extacted bounding box of the legend item. 
         Column value from left, row value from bottom."""

--- a/cdr_schemas/point_features.py
+++ b/cdr_schemas/point_features.py
@@ -25,6 +25,7 @@ class PointProperties(BaseModel):
     confidence: Optional[float] = Field(
         description="The prediction probability from the ML model"
     )
+    model_config = ConfigDict(protected_namespaces=())
     bbox: Optional[List[Union[float, int]]] = Field(
         description="""The extacted bounding box of the point item. 
         Column value from left, row value from bottom."""
@@ -39,6 +40,10 @@ class PointFeature(BaseModel):
     """
 
     type: GeoJsonType.Feature
+    id: str = Field(
+                    description="""Each point geometry has a unique id.
+                    The ids are used to link the point geometries is px-coord and geo-coord."""
+               )
     geometry: Point
     properties: PointProperties
 
@@ -58,6 +63,10 @@ class PointLegendAndFeaturesResult(BaseModel):
     """
 
     id: str = Field(description="your internal id")
+    map_cog_id: str = Field(
+                    description="""map_cog_id is used to link the extracted lines and thecorresponding geologic map"""
+    )
+    crs: str = Field(description="values={CRITICALMAAS:pixel, EPSG:*}")
     name: Optional[str] = Field(description="name of legend item")
     description: Optional[str]
     legend_bbox: Optional[List[Union[float, int]]] = Field(

--- a/cdr_schemas/polygon_features.py
+++ b/cdr_schemas/polygon_features.py
@@ -35,6 +35,10 @@ class PolygonFeature(BaseModel):
     """
 
     type: str = GeoJsonType.Feature
+    id: str = Field(
+                description="""Each polygon geometry has a unique id.
+                The ids are used to link the polygon geometries is px-coord and geo-coord."""
+           )
     geometry: Polygon
     properties: PolygonProperty
 
@@ -56,7 +60,6 @@ class MapUnit(BaseModel):
     age_text: Optional[str]
     b_age: Optional[float]
     b_interval: Optional[str]
-    description: Optional[str]
     lithology: Optional[str]
     name: Optional[str]
     t_age: Optional[float]
@@ -70,6 +73,10 @@ class PolygonLegendAndFeauturesResult(BaseModel):
     """
 
     id: str = Field(description="your internal id")
+    map_cog_id: str = Field(
+                    description="""map_cog_id is used to link the extracted lines and thecorresponding geologic map"""
+    )
+    crs: str = Field(description="values={CRITICALMAAS:pixel, EPSG:*}")
     map_unit: Optional[MapUnit]
     abbreviation: Optional[str]
     legend_bbox: Optional[List[Union[float, int]]] = Field(


### PR DESCRIPTION
I put some updates to schemas for the line/polygon/point features. Here is a summary of the updates:
1. In the **LegendAndFeaturesResult** class, I've added the fields **map_cog_id** and **crs**. **map_cog_id** links the extracted features to the corresponding geologic map, while **crs** indicates whether the features are in pixel coordinates or geographic coordinates. We prefer to store results in separate GeoJSON files for pixel coordinates and geographic coordinates.
2. The **id** field is added to each feature class. This **id** is used to link the extracted features in px-coord and geo-coord.
3. I moved the **dash pattern** and **symbol** in **line_feature.py** to the **LineProperty** class. This is because extracted line features are associated with different dash patterns and symbols.
