### PR TITLE
Abode feature result suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .ruff_cache
+
+# Vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -113,28 +113,23 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class GeomType {
+        <<Enumeration>>
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
+    }
+
     class Geom_Point {
         latitude: Union[float, int, NoneType]
         longitude: Union[float, int, NoneType]
         type: GeomType = GeomType.Point
     }
 
-    class GroundControlPoint {
-        gcp_id: str
-        map_geom: Geom_Point
-        px_geom: Pixel_Point
-        confidence: Optional[float]
-        model: str
-        model_version: str
-        crs: Optional[str]
-    }
-
-    class GeoreferenceResults {
-        cog_id: str
-        georeference_results: Optional[list[GeoreferenceResult]]
-        gcps: Optional[list[GroundControlPoint]]
-        system: str
-        system_version: str
+    class ProjectionResult {
+        crs: str
+        gcp_ids: list[str]
+        file_name: str
     }
 
     class Area_Extraction {
@@ -146,12 +141,6 @@ classDiagram
         confidence: Optional[float]
         model: Optional[str]
         model_version: Optional[str]
-    }
-
-    class ProjectionResult {
-        crs: str
-        gcp_ids: list[str]
-        file_name: str
     }
 
     class GeoreferenceResult {
@@ -166,11 +155,22 @@ classDiagram
         type: GeomType = GeomType.Point
     }
 
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
+    class GeoreferenceResults {
+        cog_id: str
+        georeference_results: Optional[list[GeoreferenceResult]]
+        gcps: Optional[list[GroundControlPoint]]
+        system: str
+        system_version: str
+    }
+
+    class GroundControlPoint {
+        gcp_id: str
+        map_geom: Geom_Point
+        px_geom: Pixel_Point
+        confidence: Optional[float]
+        model: str
+        model_version: str
+        crs: Optional[str]
     }
 
     Area_Extraction ..> GeomType
@@ -179,10 +179,10 @@ classDiagram
     Pixel_Point ..> GeomType
     GroundControlPoint ..> Geom_Point
     GroundControlPoint ..> Pixel_Point
-    GeoreferenceResult ..> ProjectionResult
     GeoreferenceResult ..> Area_Extraction
-    GeoreferenceResults ..> GroundControlPoint
+    GeoreferenceResult ..> ProjectionResult
     GeoreferenceResults ..> GeoreferenceResult
+    GeoreferenceResults ..> GroundControlPoint
 
 
 ```
@@ -196,6 +196,13 @@ classDiagram
 
 ```mermaid
 classDiagram
+
+    class MapColorSchemeTypes {
+        <<Enumeration>>
+        full_color: str = 'full_color'
+        monochrome: str = 'monochrome'
+        grayscale: str = 'grayscale'
+    }
 
     class MapMetaData {
         title: Optional[str]
@@ -211,13 +218,6 @@ classDiagram
         state: Optional[str]
         model: str
         model_version: str
-    }
-
-    class MapColorSchemeTypes {
-        <<Enumeration>>
-        full_color: str = 'full_color'
-        monochrome: str = 'monochrome'
-        grayscale: str = 'grayscale'
     }
 
     class CogMetaData {
@@ -251,9 +251,22 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class PolygonMapUnit {
-        legend: Optional[PolygonLegend] = None
-        segmentation: Optional[list[Polygon]] = None
+    class PointLegendAndFeaturesResult {
+        id: str
+        crs: str
+        cdr_projection_id: Optional[str]
+        name: Optional[str]
+        description: Optional[str]
+        legend_bbox: Optional[list[Union[float, int]]]
+        point_features: Optional[list[PointFeatureCollection]]
+    }
+
+    class CogMetaData {
+        cog_id: str
+        system: str
+        system_version: str
+        multiple_maps: Optional[bool]
+        map_metadata: Optional[list[MapMetaData]]
     }
 
     class Area_Extraction {
@@ -288,22 +301,9 @@ classDiagram
         line_features: Optional[LineFeatureCollection]
     }
 
-    class CogMetaData {
-        cog_id: str
-        system: str
-        system_version: str
-        multiple_maps: Optional[bool]
-        map_metadata: Optional[list[MapMetaData]]
-    }
-
-    class PointLegendAndFeaturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        name: Optional[str]
-        description: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        point_features: Optional[list[PointFeatureCollection]]
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[Polygon]] = None
     }
 
     Area_Extraction ..> GeomType
@@ -313,11 +313,11 @@ classDiagram
     PolygonMapUnit ..> Polygon
     PolygonMapUnit ..> PolygonLegend
     CogMetaData ..> MapMetaData
-    FeatureResults ..> PolygonMapUnit
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> LineLegendAndFeaturesResult
-    FeatureResults ..> CogMetaData
     FeatureResults ..> PointLegendAndFeaturesResult
+    FeatureResults ..> CogMetaData
+    FeatureResults ..> Area_Extraction
+    FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> LineLegendAndFeaturesResult
 
 
 ```
@@ -332,6 +332,19 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class PointFeature {
+        type: GeoJsonType = GeoJsonType.Feature
+        id: str
+        geometry: Point
+        properties: PointProperties
+    }
+
+    class GeoJsonType {
+        <<Enumeration>>
+        Feature: str = 'Feature'
+        FeatureCollection: str = 'FeatureCollection'
+    }
+
     class GeomType {
         <<Enumeration>>
         Point: str = 'Point'
@@ -344,12 +357,6 @@ classDiagram
         features: list[PointFeature]
     }
 
-    class GeoJsonType {
-        <<Enumeration>>
-        Feature: str = 'Feature'
-        FeatureCollection: str = 'FeatureCollection'
-    }
-
     class PointLegendAndFeaturesResult {
         id: str
         crs: str
@@ -358,18 +365,6 @@ classDiagram
         description: Optional[str]
         legend_bbox: Optional[list[Union[float, int]]]
         point_features: Optional[list[PointFeatureCollection]]
-    }
-
-    class Point {
-        coordinates: list[Union[float, int]]
-        type: GeomType = GeomType.Point
-    }
-
-    class PointFeature {
-        type: GeoJsonType = GeoJsonType.Feature
-        id: str
-        geometry: Point
-        properties: PointProperties
     }
 
     class PointProperties {
@@ -381,9 +376,14 @@ classDiagram
         dip_direction: Optional[int]
     }
 
+    class Point {
+        coordinates: list[Union[float, int]]
+        type: GeomType = GeomType.Point
+    }
+
     Point ..> GeomType
-    PointFeature ..> Point
     PointFeature ..> GeoJsonType
+    PointFeature ..> Point
     PointFeature ..> PointProperties
     PointFeatureCollection ..> PointFeature
     PointFeatureCollection ..> GeoJsonType
@@ -402,37 +402,24 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class LineFeature {
+        type: GeoJsonType = GeoJsonType.Feature
+        id: str
+        geometry: Line
+        properties: LineProperty
+    }
+
     class GeoJsonType {
         <<Enumeration>>
         Feature: str = 'Feature'
         FeatureCollection: str = 'FeatureCollection'
     }
 
-    class DashType {
+    class GeomType {
         <<Enumeration>>
-        solid: str = 'solid'
-        dash: str = 'dash'
-        dotted: str = 'dotted'
-    }
-
-    class Line {
-        coordinates: list[list[Union[float, int]]]
-        type: GeomType = GeomType.LineString
-    }
-
-    class LineProperty {
-        model: Optional[str]
-        model_version: Optional[str]
-        confidence: Optional[float]
-        dash_pattern: Optional[DashType] = None
-        symbol: Optional[str]
-    }
-
-    class LineFeature {
-        type: GeoJsonType = GeoJsonType.Feature
-        id: str
-        geometry: Line
-        properties: LineProperty
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
     }
 
     class LineLegendAndFeaturesResult {
@@ -445,11 +432,19 @@ classDiagram
         line_features: Optional[LineFeatureCollection]
     }
 
-    class GeomType {
+    class LineProperty {
+        model: Optional[str]
+        model_version: Optional[str]
+        confidence: Optional[float]
+        dash_pattern: Optional[DashType] = None
+        symbol: Optional[str]
+    }
+
+    class DashType {
         <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
+        solid: str = 'solid'
+        dash: str = 'dash'
+        dotted: str = 'dotted'
     }
 
     class LineFeatureCollection {
@@ -457,11 +452,16 @@ classDiagram
         features: Optional[list[LineFeature]]
     }
 
+    class Line {
+        coordinates: list[list[Union[float, int]]]
+        type: GeomType = GeomType.LineString
+    }
+
     Line ..> GeomType
     LineProperty ..> DashType
-    LineFeature ..> Line
-    LineFeature ..> LineProperty
     LineFeature ..> GeoJsonType
+    LineFeature ..> LineProperty
+    LineFeature ..> Line
     LineFeatureCollection ..> LineFeature
     LineFeatureCollection ..> GeoJsonType
     LineLegendAndFeaturesResult ..> LineFeatureCollection
@@ -481,14 +481,9 @@ classDiagram
 
     class Polygon {
         provenance: ModelProvenance
-        crs: Optional[str] = None
+        crs: Optional[str] = 'pixel'
         cdr_projection_id: Optional[str] = None
         geometry: list[list[Union[float, int]]]
-    }
-
-    class PolygonMapUnit {
-        legend: Optional[PolygonLegend] = None
-        segmentation: Optional[list[Polygon]] = None
     }
 
     class ModelProvenance {
@@ -502,7 +497,8 @@ classDiagram
         label: Optional[str] = None
         abbreviation: Optional[str] = None
         description: Optional[str] = None
-        legend_bbox: Optional[list[list[Union[float, int]]]] = None
+        legend_bbox: Optional[list[Union[float, int]]] = None
+        legend_contour: Optional[list[list[Union[float, int]]]] = None
         color: Optional[str] = None
         pattern: Optional[str] = None
         overlay: Optional[bool] = None
@@ -514,6 +510,11 @@ classDiagram
         t_age: Optional[float] = None
         t_interval: Optional[str] = None
         comments: Optional[str] = None
+    }
+
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[Polygon]] = None
     }
 
     Polygon ..> ModelProvenance
@@ -534,6 +535,13 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class MapColorSchemeTypes {
+        <<Enumeration>>
+        full_color: str = 'full_color'
+        monochrome: str = 'monochrome'
+        grayscale: str = 'grayscale'
+    }
+
     class MapMetaData {
         title: Optional[str]
         year: Optional[int]
@@ -548,13 +556,6 @@ classDiagram
         state: Optional[str]
         model: str
         model_version: str
-    }
-
-    class MapColorSchemeTypes {
-        <<Enumeration>>
-        full_color: str = 'full_color'
-        monochrome: str = 'monochrome'
-        grayscale: str = 'grayscale'
     }
 
     class CogMetaData {
@@ -588,24 +589,16 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class DocumentExtraction {
-        id: UnionType[str, NoneType] = None
-        document_id: str = None
-        extraction_type: str
-        extraction_label: str
-        score: UnionType[float, NoneType] = None
-        bbox: UnionType[tuple[float, float, float, float], NoneType] = None
-        page_num: UnionType[int, NoneType] = None
-        external_link: UnionType[str, NoneType] = None
-        data: Optional[dict[]] = None
+    class Document {
+        id: str
+        title: str
+        is_open: bool
+        pages: int
+        size: int
+        provenance: list[DocumentProvenance] = list
+        metadata: Optional[DocumentMetaData] = None
         system: str
         system_version: str
-    }
-
-    class DocumentProvenance {
-        external_system_name: str
-        external_system_id: Optional[str] = ''
-        external_system_url: Optional[str] = ''
     }
 
     class UploadDocument {
@@ -615,6 +608,12 @@ classDiagram
         metadata: Optional[DocumentMetaData] = None
         system: str
         system_version: str
+    }
+
+    class DocumentProvenance {
+        external_system_name: str
+        external_system_id: Optional[str] = ''
+        external_system_url: Optional[str] = ''
     }
 
     class DocumentMetaData {
@@ -628,14 +627,16 @@ classDiagram
         description: str = ''
     }
 
-    class Document {
-        id: str
-        title: str
-        is_open: bool
-        pages: int
-        size: int
-        provenance: list[DocumentProvenance] = list
-        metadata: Optional[DocumentMetaData] = None
+    class DocumentExtraction {
+        id: UnionType[str, NoneType] = None
+        document_id: str = None
+        extraction_type: str
+        extraction_label: str
+        score: UnionType[float, NoneType] = None
+        bbox: UnionType[tuple[float, float, float, float], NoneType] = None
+        page_num: UnionType[int, NoneType] = None
+        external_link: UnionType[str, NoneType] = None
+        data: Optional[dict[]] = None
         system: str
         system_version: str
     }
@@ -658,70 +659,6 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class MineralSite {
-        source_id: str
-        record_id: str
-        name: Optional[str]
-        mineral_inventory: list[MineralInventory]
-        location_info: LocationInfo
-        geology_info: Optional[GeologyInfo]
-        deposit_type_candidate: list[DepositTypeCandidate]
-    }
-
-    class MappableCriteria {
-        criteria: str
-        theoretical: Optional[str]
-        potential_dataset: Optional[list[EvidenceLayer]]
-        supporting_references: list[Reference]
-    }
-
-    class Ore {
-        ore_unit: str
-        ore_value: float
-    }
-
-    class Geometry {
-        <<Enumeration>>
-        Point: str = 'Point'
-        Polygon: str = 'Polygon'
-    }
-
-    class Grade {
-        grade_unit: str
-        grade_value: float
-    }
-
-    class Commodity {
-        name: str
-    }
-
-    class DepositTypeCandidate {
-        observed_name: str
-        normalized_uri: DepositType
-        confidence: float
-        source: str
-    }
-
-    class MineralSystem {
-        deposit_type: list[DepositType]
-        source: list[MappableCriteria]
-        pathway: list[MappableCriteria]
-        trap: Optional[list[MappableCriteria]]
-        preservation: Optional[list[MappableCriteria]]
-        energy: Optional[list[MappableCriteria]]
-        outflow: Optional[list[MappableCriteria]]
-    }
-
-    class EvidenceLayer {
-        name: str
-        relevance_score: float
-    }
-
-    class PageInfo {
-        page: int
-        bounding_box: Optional[BoundingBox]
-    }
-
     class Document {
         id: str
         title: str
@@ -732,6 +669,24 @@ classDiagram
         metadata: Optional[DocumentMetaData] = None
         system: str
         system_version: str
+    }
+
+    class Reference {
+        document: Document
+        page_info: list[PageInfo]
+    }
+
+    class Geometry {
+        <<Enumeration>>
+        Point: str = 'Point'
+        Polygon: str = 'Polygon'
+    }
+
+    class BoundingBox {
+        x_min: float
+        x_max: float
+        y_min: float
+        y_max: float
     }
 
     class MineralInventory {
@@ -747,6 +702,16 @@ classDiagram
         zone: Optional[str]
     }
 
+    class MineralSite {
+        source_id: str
+        record_id: str
+        name: Optional[str]
+        mineral_inventory: list[MineralInventory]
+        location_info: LocationInfo
+        geology_info: Optional[GeologyInfo]
+        deposit_type_candidate: list[DepositTypeCandidate]
+    }
+
     class ResourceReserveCategory {
         <<Enumeration>>
         INFERRED: str = 'Inferred Mineral Resource'
@@ -756,16 +721,19 @@ classDiagram
         PROVEN: str = 'Proven Mineral Reserve'
     }
 
-    class BoundingBox {
-        x_min: float
-        x_max: float
-        y_min: float
-        y_max: float
+    class EvidenceLayer {
+        name: str
+        relevance_score: float
     }
 
-    class Reference {
-        document: Document
-        page_info: list[PageInfo]
+    class MineralSystem {
+        deposit_type: list[DepositType]
+        source: list[MappableCriteria]
+        pathway: list[MappableCriteria]
+        trap: Optional[list[MappableCriteria]]
+        preservation: Optional[list[MappableCriteria]]
+        energy: Optional[list[MappableCriteria]]
+        outflow: Optional[list[MappableCriteria]]
     }
 
     class LocationInfo {
@@ -773,12 +741,6 @@ classDiagram
         crs: str
         country: Optional[str]
         state_or_province: Optional[str]
-    }
-
-    class DepositType {
-        name: str
-        environment: str
-        group: str
     }
 
     class GeologyInfo {
@@ -791,27 +753,66 @@ classDiagram
         comments: Optional[str]
     }
 
+    class DepositTypeCandidate {
+        observed_name: str
+        normalized_uri: DepositType
+        confidence: float
+        source: str
+    }
+
+    class Ore {
+        ore_unit: str
+        ore_value: float
+    }
+
+    class PageInfo {
+        page: int
+        bounding_box: Optional[BoundingBox]
+    }
+
+    class DepositType {
+        name: str
+        environment: str
+        group: str
+    }
+
+    class Grade {
+        grade_unit: str
+        grade_value: float
+    }
+
+    class Commodity {
+        name: str
+    }
+
+    class MappableCriteria {
+        criteria: str
+        theoretical: Optional[str]
+        potential_dataset: Optional[list[EvidenceLayer]]
+        supporting_references: list[Reference]
+    }
+
     Document ..> DocumentMetaData
     Document ..> DocumentProvenance
     DepositTypeCandidate ..> DepositType
     PageInfo ..> BoundingBox
-    Reference ..> PageInfo
     Reference ..> Document
+    Reference ..> PageInfo
     MappableCriteria ..> Reference
     MappableCriteria ..> EvidenceLayer
-    MineralSystem ..> MappableCriteria
     MineralSystem ..> DepositType
-    MineralInventory ..> datetime
-    MineralInventory ..> Ore
+    MineralSystem ..> MappableCriteria
     MineralInventory ..> ResourceReserveCategory
     MineralInventory ..> Grade
     MineralInventory ..> Reference
     MineralInventory ..> Commodity
+    MineralInventory ..> Ore
+    MineralInventory ..> datetime
     LocationInfo ..> Geometry
-    MineralSite ..> DepositTypeCandidate
-    MineralSite ..> MineralInventory
     MineralSite ..> LocationInfo
     MineralSite ..> GeologyInfo
+    MineralSite ..> DepositTypeCandidate
+    MineralSite ..> MineralInventory
 
 
 ```
@@ -825,14 +826,6 @@ classDiagram
 
 ```mermaid
 classDiagram
-
-    class GeoreferenceResults {
-        cog_id: str
-        georeference_results: Optional[list[GeoreferenceResult]]
-        gcps: Optional[list[GroundControlPoint]]
-        system: str
-        system_version: str
-    }
 
     class MapResults {
         cog_id: str
@@ -851,13 +844,21 @@ classDiagram
         cog_metadata_extractions: Optional[list[CogMetaData]] = None
     }
 
-    FeatureResults ..> PolygonMapUnit
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> LineLegendAndFeaturesResult
-    FeatureResults ..> CogMetaData
+    class GeoreferenceResults {
+        cog_id: str
+        georeference_results: Optional[list[GeoreferenceResult]]
+        gcps: Optional[list[GroundControlPoint]]
+        system: str
+        system_version: str
+    }
+
     FeatureResults ..> PointLegendAndFeaturesResult
-    GeoreferenceResults ..> GroundControlPoint
+    FeatureResults ..> CogMetaData
+    FeatureResults ..> Area_Extraction
+    FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> LineLegendAndFeaturesResult
     GeoreferenceResults ..> GeoreferenceResult
+    GeoreferenceResults ..> GroundControlPoint
     MapResults ..> GeoreferenceResults
     MapResults ..> FeatureResults
 
@@ -874,18 +875,18 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class MapProvenance {
+        system_name: str
+        id: str = None
+        url: str = None
+    }
+
     class Map {
         id: str
         provenance: Optional[list[MapProvenance]] = None
         is_open: bool
         system: str
         system_version: str
-    }
-
-    class MapProvenance {
-        system_name: str
-        id: str = None
-        url: str = None
     }
 
     Map ..> MapProvenance

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ poetry run docs
 ```mermaid
 classDiagram
 
+    class Area_Extraction {
+        type: GeomType = GeomType.Polygon
+        coordinates: list[list[list[Union[float, int]]]]
+        bbox: Optional[list[Union[float, int]]]
+        category: AreaType
+        text: Optional[str]
+        confidence: Optional[float]
+        model: Optional[str]
+        model_version: Optional[str]
+    }
+
     class AreaType {
         <<Enumeration>>
         Map_Area: str = 'Map_Area'
@@ -77,17 +88,6 @@ classDiagram
         Line_Legend_Area: str = 'Line_Legend_Area'
         Point_Legend_Area: str = 'Point_Legend_Area'
         Correlation_Diagram: str = 'Correlation_Diagram'
-    }
-
-    class Area_Extraction {
-        type: GeomType = GeomType.Polygon
-        coordinates: list[list[list[Union[float, int]]]]
-        bbox: Optional[list[Union[float, int]]]
-        category: AreaType
-        text: Optional[str]
-        confidence: Optional[float]
-        model: Optional[str]
-        model_version: Optional[str]
     }
 
     class GeomType {
@@ -113,10 +113,10 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class GeoreferenceResult {
-        likely_CRSs: Optional[list[str]]
-        map_area: Optional[Area_Extraction]
-        projections: Optional[list[ProjectionResult]]
+    class Geom_Point {
+        latitude: Union[float, int, NoneType]
+        longitude: Union[float, int, NoneType]
+        type: GeomType = GeomType.Point
     }
 
     class Area_Extraction {
@@ -130,17 +130,16 @@ classDiagram
         model_version: Optional[str]
     }
 
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
-    }
-
     class Pixel_Point {
         rows_from_top: Union[float, int]
         columns_from_left: Union[float, int]
         type: GeomType = GeomType.Point
+    }
+
+    class GeoreferenceResult {
+        likely_CRSs: Optional[list[str]]
+        map_area: Optional[Area_Extraction]
+        projections: Optional[list[ProjectionResult]]
     }
 
     class ProjectionResult {
@@ -149,14 +148,11 @@ classDiagram
         file_name: str
     }
 
-    class GroundControlPoint {
-        gcp_id: str
-        map_geom: Geom_Point
-        px_geom: Pixel_Point
-        confidence: Optional[float]
-        model: str
-        model_version: str
-        crs: Optional[str]
+    class GeomType {
+        <<Enumeration>>
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
     }
 
     class GeoreferenceResults {
@@ -167,10 +163,14 @@ classDiagram
         system_version: str
     }
 
-    class Geom_Point {
-        latitude: Union[float, int, NoneType]
-        longitude: Union[float, int, NoneType]
-        type: GeomType = GeomType.Point
+    class GroundControlPoint {
+        gcp_id: str
+        map_geom: Geom_Point
+        px_geom: Pixel_Point
+        confidence: Optional[float]
+        model: str
+        model_version: str
+        crs: Optional[str]
     }
 
     Area_Extraction ..> AreaType
@@ -197,12 +197,6 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class MapShapeTypes {
-        <<Enumeration>>
-        rectangular: str = 'rectangular'
-        non_rectangular: str = 'non_rectangular'
-    }
-
     class MapMetaData {
         title: Optional[str]
         year: Optional[int]
@@ -217,6 +211,12 @@ classDiagram
         state: Optional[str]
         model: str
         model_version: str
+    }
+
+    class MapShapeTypes {
+        <<Enumeration>>
+        rectangular: str = 'rectangular'
+        non_rectangular: str = 'non_rectangular'
     }
 
     class CogMetaData {
@@ -251,6 +251,16 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class LineLegendAndFeaturesResult {
+        id: str
+        crs: str
+        cdr_projection_id: Optional[str]
+        name: Optional[str]
+        description: Optional[str]
+        legend_bbox: Optional[list[Union[float, int]]]
+        line_features: Optional[LineFeatureCollection]
+    }
+
     class Area_Extraction {
         type: GeomType = GeomType.Polygon
         coordinates: list[list[list[Union[float, int]]]]
@@ -260,6 +270,19 @@ classDiagram
         confidence: Optional[float]
         model: Optional[str]
         model_version: Optional[str]
+    }
+
+    class CogMetaData {
+        cog_id: str
+        system: str
+        system_version: str
+        multiple_maps: Optional[bool]
+        map_metadata: Optional[list[MapMetaData]]
+    }
+
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[PolygonSegmentation]] = None
     }
 
     class PointLegendAndFeaturesResult {
@@ -272,61 +295,29 @@ classDiagram
         point_features: Optional[list[PointFeatureCollection]]
     }
 
-    class PolygonLegendAndFeauturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        map_unit: Optional[MapUnit]
-        abbreviation: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        category: Optional[str]
-        color: Optional[str]
-        description: Optional[str]
-        pattern: Optional[str]
-        polygon_features: Optional[PolygonFeatureCollection]
-    }
-
-    class LineLegendAndFeaturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        name: Optional[str]
-        description: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        line_features: Optional[LineFeatureCollection]
-    }
-
     class FeatureResults {
-        cog_id: str
-        line_feature_results: Optional[list[LineLegendAndFeaturesResult]]
-        point_feature_results: Optional[list[PointLegendAndFeaturesResult]]
-        polygon_feature_results: Optional[list[PolygonLegendAndFeauturesResult]]
-        cog_area_extractions: Optional[list[Area_Extraction]]
-        cog_metadata_extractions: Optional[list[CogMetaData]]
         system: str
         system_version: str
-    }
-
-    class CogMetaData {
         cog_id: str
-        system: str
-        system_version: str
-        multiple_maps: Optional[bool]
-        map_metadata: Optional[list[MapMetaData]]
+        line_feature_results: Optional[list[LineLegendAndFeaturesResult]] = None
+        point_feature_results: Optional[list[PointLegendAndFeaturesResult]] = None
+        polygon_features: Optional[list[PolygonMapUnit]] = None
+        cog_area_extractions: Optional[list[Area_Extraction]] = None
+        cog_metadata_extractions: Optional[list[CogMetaData]] = None
     }
 
     Area_Extraction ..> AreaType
     Area_Extraction ..> GeomType
     LineLegendAndFeaturesResult ..> LineFeatureCollection
     PointLegendAndFeaturesResult ..> PointFeatureCollection
-    PolygonLegendAndFeauturesResult ..> PolygonFeatureCollection
-    PolygonLegendAndFeauturesResult ..> MapUnit
+    PolygonMapUnit ..> PolygonSegmentation
+    PolygonMapUnit ..> PolygonLegend
     CogMetaData ..> MapMetaData
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> PointLegendAndFeaturesResult
-    FeatureResults ..> PolygonLegendAndFeauturesResult
     FeatureResults ..> LineLegendAndFeaturesResult
+    FeatureResults ..> Area_Extraction
     FeatureResults ..> CogMetaData
+    FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> PointLegendAndFeaturesResult
 
 
 ```
@@ -340,6 +331,18 @@ classDiagram
 
 ```mermaid
 classDiagram
+
+    class PointFeatureCollection {
+        type: GeoJsonType = GeoJsonType.FeatureCollection
+        features: list[PointFeature]
+    }
+
+    class PointFeature {
+        type: GeoJsonType = GeoJsonType.Feature
+        id: str
+        geometry: Point
+        properties: PointProperties
+    }
 
     class PointProperties {
         model: Optional[str]
@@ -360,18 +363,16 @@ classDiagram
         point_features: Optional[list[PointFeatureCollection]]
     }
 
+    class Point {
+        coordinates: list[Union[float, int]]
+        type: GeomType = GeomType.Point
+    }
+
     class GeomType {
         <<Enumeration>>
         Point: str = 'Point'
         LineString: str = 'LineString'
         Polygon: str = 'Polygon'
-    }
-
-    class PointFeature {
-        type: GeoJsonType = GeoJsonType.Feature
-        id: str
-        geometry: Point
-        properties: PointProperties
     }
 
     class GeoJsonType {
@@ -380,22 +381,12 @@ classDiagram
         FeatureCollection: str = 'FeatureCollection'
     }
 
-    class Point {
-        coordinates: list[Union[float, int]]
-        type: GeomType = GeomType.Point
-    }
-
-    class PointFeatureCollection {
-        type: GeoJsonType = GeoJsonType.FeatureCollection
-        features: list[PointFeature]
-    }
-
     Point ..> GeomType
-    PointFeature ..> GeoJsonType
     PointFeature ..> PointProperties
     PointFeature ..> Point
-    PointFeatureCollection ..> GeoJsonType
+    PointFeature ..> GeoJsonType
     PointFeatureCollection ..> PointFeature
+    PointFeatureCollection ..> GeoJsonType
     PointLegendAndFeaturesResult ..> PointFeatureCollection
 
 
@@ -411,9 +402,21 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class LineFeatureCollection {
+        type: GeoJsonType = GeoJsonType.FeatureCollection
+        features: Optional[list[LineFeature]]
+    }
+
     class Line {
         coordinates: list[list[Union[float, int]]]
         type: GeomType = GeomType.LineString
+    }
+
+    class DashType {
+        <<Enumeration>>
+        solid: str = 'solid'
+        dash: str = 'dash'
+        dotted: str = 'dotted'
     }
 
     class GeomType {
@@ -421,6 +424,13 @@ classDiagram
         Point: str = 'Point'
         LineString: str = 'LineString'
         Polygon: str = 'Polygon'
+    }
+
+    class LineFeature {
+        type: GeoJsonType = GeoJsonType.Feature
+        id: str
+        geometry: Line
+        properties: LineProperty
     }
 
     class LineLegendAndFeaturesResult {
@@ -433,31 +443,6 @@ classDiagram
         line_features: Optional[LineFeatureCollection]
     }
 
-    class GeoJsonType {
-        <<Enumeration>>
-        Feature: str = 'Feature'
-        FeatureCollection: str = 'FeatureCollection'
-    }
-
-    class DashType {
-        <<Enumeration>>
-        solid: str = 'solid'
-        dash: str = 'dash'
-        dotted: str = 'dotted'
-    }
-
-    class LineFeature {
-        type: GeoJsonType = GeoJsonType.Feature
-        id: str
-        geometry: Line
-        properties: LineProperty
-    }
-
-    class LineFeatureCollection {
-        type: GeoJsonType = GeoJsonType.FeatureCollection
-        features: Optional[list[LineFeature]]
-    }
-
     class LineProperty {
         model: Optional[str]
         model_version: Optional[str]
@@ -466,13 +451,19 @@ classDiagram
         symbol: Optional[str]
     }
 
+    class GeoJsonType {
+        <<Enumeration>>
+        Feature: str = 'Feature'
+        FeatureCollection: str = 'FeatureCollection'
+    }
+
     Line ..> GeomType
     LineProperty ..> DashType
     LineFeature ..> LineProperty
-    LineFeature ..> GeoJsonType
     LineFeature ..> Line
-    LineFeatureCollection ..> GeoJsonType
+    LineFeature ..> GeoJsonType
     LineFeatureCollection ..> LineFeature
+    LineFeatureCollection ..> GeoJsonType
     LineLegendAndFeaturesResult ..> LineFeatureCollection
 
 
@@ -488,75 +479,37 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[PolygonSegmentation]] = None
     }
 
-    class PolygonFeature {
-        type: GeoJsonType = GeoJsonType.Feature
-        id: str
-        geometry: Polygon
-        properties: PolygonProperty
+    class PolygonSegmentation {
+        provenance: ModelProvenance
+        geometry: list[list[list[Union[float, int]]]]
     }
 
-    class PolygonLegendAndFeauturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        map_unit: Optional[MapUnit]
-        abbreviation: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        category: Optional[str]
-        color: Optional[str]
-        description: Optional[str]
-        pattern: Optional[str]
-        polygon_features: Optional[PolygonFeatureCollection]
+    class PolygonLegend {
+        provenance: ModelProvenance
+        label: Optional[str] = None
+        abbreviation: Optional[str] = None
+        description: Optional[str] = None
+        legend_bbox: Optional[list[list[Union[float, int]]]] = None
+        color: Optional[str] = None
+        pattern: Optional[str] = None
+        overlay: Optional[bool] = None
     }
 
-    class GeoJsonType {
-        <<Enumeration>>
-        Feature: str = 'Feature'
-        FeatureCollection: str = 'FeatureCollection'
+    class ModelProvenance {
+        model: Optional[str] = None
+        model_version: Optional[str] = None
+        confidence: Optional[float] = None
     }
 
-    class PolygonFeatureCollection {
-        type: GeoJsonType = GeoJsonType.FeatureCollection
-        features: Optional[list[PolygonFeature]]
-    }
-
-    class PolygonProperty {
-        model: Optional[str]
-        model_version: Optional[str]
-        confidence: Optional[float]
-    }
-
-    class Polygon {
-        coordinates: list[list[list[Union[float, int]]]]
-        type: GeomType = GeomType.Polygon
-    }
-
-    class MapUnit {
-        age_text: Optional[str]
-        b_age: Optional[float]
-        b_interval: Optional[str]
-        lithology: Optional[str]
-        name: Optional[str]
-        t_age: Optional[float]
-        t_interval: Optional[str]
-        comments: Optional[str]
-    }
-
-    Polygon ..> GeomType
-    PolygonFeature ..> PolygonProperty
-    PolygonFeature ..> GeoJsonType
-    PolygonFeature ..> Polygon
-    PolygonFeatureCollection ..> GeoJsonType
-    PolygonFeatureCollection ..> PolygonFeature
-    PolygonLegendAndFeauturesResult ..> PolygonFeatureCollection
-    PolygonLegendAndFeauturesResult ..> MapUnit
+    PolygonSegmentation ..> ModelProvenance
+    PolygonLegend ..> ModelProvenance
+    PolygonMapUnit ..> PolygonSegmentation
+    PolygonMapUnit ..> PolygonLegend
 
 
 ```
@@ -570,12 +523,6 @@ classDiagram
 
 ```mermaid
 classDiagram
-
-    class MapShapeTypes {
-        <<Enumeration>>
-        rectangular: str = 'rectangular'
-        non_rectangular: str = 'non_rectangular'
-    }
 
     class MapMetaData {
         title: Optional[str]
@@ -591,6 +538,12 @@ classDiagram
         state: Optional[str]
         model: str
         model_version: str
+    }
+
+    class MapShapeTypes {
+        <<Enumeration>>
+        rectangular: str = 'rectangular'
+        non_rectangular: str = 'non_rectangular'
     }
 
     class CogMetaData {
@@ -625,6 +578,12 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class DocumentProvenance {
+        external_system_name: str
+        external_system_id: Optional[str] = ''
+        external_system_url: Optional[str] = ''
+    }
+
     class UploadDocument {
         title: str
         is_open: bool = True
@@ -648,6 +607,17 @@ classDiagram
         system_version: str
     }
 
+    class DocumentMetaData {
+        doi: str = ''
+        authors: list[str] = list
+        journal: str = ''
+        year: Optional[int] = None
+        month: Optional[int] = None
+        volume: Optional[int] = None
+        issue: Optional[int] = None
+        description: str = ''
+    }
+
     class Document {
         id: str
         title: str
@@ -660,27 +630,10 @@ classDiagram
         system_version: str
     }
 
-    class DocumentMetaData {
-        doi: str = ''
-        authors: list[str] = list
-        journal: str = ''
-        year: Optional[int] = None
-        month: Optional[int] = None
-        volume: Optional[int] = None
-        issue: Optional[int] = None
-        description: str = ''
-    }
-
-    class DocumentProvenance {
-        external_system_name: str
-        external_system_id: Optional[str] = ''
-        external_system_url: Optional[str] = ''
-    }
-
-    UploadDocument ..> DocumentMetaData
     UploadDocument ..> DocumentProvenance
-    Document ..> DocumentMetaData
+    UploadDocument ..> DocumentMetaData
     Document ..> DocumentProvenance
+    Document ..> DocumentMetaData
 
 
 ```
@@ -695,38 +648,8 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class PageInfo {
-        page: int
-        bounding_box: Optional[BoundingBox]
-    }
-
-    class EvidenceLayer {
+    class Commodity {
         name: str
-        relevance_score: float
-    }
-
-    class Reference {
-        document: Document
-        page_info: list[PageInfo]
-    }
-
-    class MineralSystem {
-        deposit_type: list[DepositType]
-        source: list[MappableCriteria]
-        pathway: list[MappableCriteria]
-        trap: Optional[list[MappableCriteria]]
-        preservation: Optional[list[MappableCriteria]]
-        energy: Optional[list[MappableCriteria]]
-        outflow: Optional[list[MappableCriteria]]
-    }
-
-    class ResourceReserveCategory {
-        <<Enumeration>>
-        INFERRED: str = 'Inferred Mineral Resource'
-        INDICATED: str = 'Indicated Mineral Resource'
-        MEASURED: str = 'Measured Mineral Resource'
-        PROBABLE: str = 'Probable Mineral Reserve'
-        PROVEN: str = 'Proven Mineral Reserve'
     }
 
     class DepositTypeCandidate {
@@ -734,33 +657,6 @@ classDiagram
         normalized_uri: DepositType
         confidence: float
         source: str
-    }
-
-    class MappableCriteria {
-        criteria: str
-        theoretical: Optional[str]
-        potential_dataset: Optional[list[EvidenceLayer]]
-        supporting_references: list[Reference]
-    }
-
-    class Ore {
-        ore_unit: str
-        ore_value: float
-    }
-
-    class MineralSite {
-        source_id: str
-        record_id: str
-        name: Optional[str]
-        mineral_inventory: list[MineralInventory]
-        location_info: LocationInfo
-        geology_info: Optional[GeologyInfo]
-        deposit_type_candidate: list[DepositTypeCandidate]
-    }
-
-    class Grade {
-        grade_unit: str
-        grade_value: float
     }
 
     class Document {
@@ -775,6 +671,56 @@ classDiagram
         system_version: str
     }
 
+    class MineralSite {
+        source_id: str
+        record_id: str
+        name: Optional[str]
+        mineral_inventory: list[MineralInventory]
+        location_info: LocationInfo
+        geology_info: Optional[GeologyInfo]
+        deposit_type_candidate: list[DepositTypeCandidate]
+    }
+
+    class Geometry {
+        <<Enumeration>>
+        Point: str = 'Point'
+        Polygon: str = 'Polygon'
+    }
+
+    class DepositType {
+        name: str
+        environment: str
+        group: str
+    }
+
+    class MappableCriteria {
+        criteria: str
+        theoretical: Optional[str]
+        potential_dataset: Optional[list[EvidenceLayer]]
+        supporting_references: list[Reference]
+    }
+
+    class Grade {
+        grade_unit: str
+        grade_value: float
+    }
+
+    class LocationInfo {
+        location: Geometry
+        crs: str
+        country: Optional[str]
+        state_or_province: Optional[str]
+    }
+
+    class ResourceReserveCategory {
+        <<Enumeration>>
+        INFERRED: str = 'Inferred Mineral Resource'
+        INDICATED: str = 'Indicated Mineral Resource'
+        MEASURED: str = 'Measured Mineral Resource'
+        PROBABLE: str = 'Probable Mineral Reserve'
+        PROVEN: str = 'Proven Mineral Reserve'
+    }
+
     class GeologyInfo {
         age: Optional[str]
         unit_name: Optional[str]
@@ -783,6 +729,38 @@ classDiagram
         process: Optional[list[str]]
         environment: Optional[list[str]]
         comments: Optional[str]
+    }
+
+    class PageInfo {
+        page: int
+        bounding_box: Optional[BoundingBox]
+    }
+
+    class BoundingBox {
+        x_min: float
+        x_max: float
+        y_min: float
+        y_max: float
+    }
+
+    class Reference {
+        document: Document
+        page_info: list[PageInfo]
+    }
+
+    class Ore {
+        ore_unit: str
+        ore_value: float
+    }
+
+    class MineralSystem {
+        deposit_type: list[DepositType]
+        source: list[MappableCriteria]
+        pathway: list[MappableCriteria]
+        trap: Optional[list[MappableCriteria]]
+        preservation: Optional[list[MappableCriteria]]
+        energy: Optional[list[MappableCriteria]]
+        outflow: Optional[list[MappableCriteria]]
     }
 
     class MineralInventory {
@@ -798,57 +776,32 @@ classDiagram
         zone: Optional[str]
     }
 
-    class DepositType {
+    class EvidenceLayer {
         name: str
-        environment: str
-        group: str
+        relevance_score: float
     }
 
-    class LocationInfo {
-        location: Geometry
-        crs: str
-        country: Optional[str]
-        state_or_province: Optional[str]
-    }
-
-    class Commodity {
-        name: str
-    }
-
-    class BoundingBox {
-        x_min: float
-        x_max: float
-        y_min: float
-        y_max: float
-    }
-
-    class Geometry {
-        <<Enumeration>>
-        Point: str = 'Point'
-        Polygon: str = 'Polygon'
-    }
-
-    Document ..> DocumentMetaData
     Document ..> DocumentProvenance
+    Document ..> DocumentMetaData
     DepositTypeCandidate ..> DepositType
     PageInfo ..> BoundingBox
     Reference ..> PageInfo
     Reference ..> Document
-    MappableCriteria ..> EvidenceLayer
     MappableCriteria ..> Reference
+    MappableCriteria ..> EvidenceLayer
     MineralSystem ..> MappableCriteria
     MineralSystem ..> DepositType
-    MineralInventory ..> datetime
-    MineralInventory ..> ResourceReserveCategory
-    MineralInventory ..> Reference
-    MineralInventory ..> Ore
     MineralInventory ..> Commodity
+    MineralInventory ..> Ore
+    MineralInventory ..> Reference
     MineralInventory ..> Grade
+    MineralInventory ..> ResourceReserveCategory
+    MineralInventory ..> datetime
     LocationInfo ..> Geometry
-    MineralSite ..> LocationInfo
-    MineralSite ..> MineralInventory
-    MineralSite ..> GeologyInfo
     MineralSite ..> DepositTypeCandidate
+    MineralSite ..> LocationInfo
+    MineralSite ..> GeologyInfo
+    MineralSite ..> MineralInventory
 
 
 ```
@@ -872,14 +825,14 @@ classDiagram
     }
 
     class FeatureResults {
-        cog_id: str
-        line_feature_results: Optional[list[LineLegendAndFeaturesResult]]
-        point_feature_results: Optional[list[PointLegendAndFeaturesResult]]
-        polygon_feature_results: Optional[list[PolygonLegendAndFeauturesResult]]
-        cog_area_extractions: Optional[list[Area_Extraction]]
-        cog_metadata_extractions: Optional[list[CogMetaData]]
         system: str
         system_version: str
+        cog_id: str
+        line_feature_results: Optional[list[LineLegendAndFeaturesResult]] = None
+        point_feature_results: Optional[list[PointLegendAndFeaturesResult]] = None
+        polygon_features: Optional[list[PolygonMapUnit]] = None
+        cog_area_extractions: Optional[list[Area_Extraction]] = None
+        cog_metadata_extractions: Optional[list[CogMetaData]] = None
     }
 
     class MapResults {
@@ -888,11 +841,11 @@ classDiagram
         extraction_results: Optional[list[FeatureResults]]
     }
 
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> PointLegendAndFeaturesResult
-    FeatureResults ..> PolygonLegendAndFeauturesResult
     FeatureResults ..> LineLegendAndFeaturesResult
+    FeatureResults ..> Area_Extraction
     FeatureResults ..> CogMetaData
+    FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> PointLegendAndFeaturesResult
     GeoreferenceResults ..> GeoreferenceResult
     GeoreferenceResults ..> GroundControlPoint
     MapResults ..> GeoreferenceResults

--- a/README.md
+++ b/README.md
@@ -66,15 +66,11 @@ poetry run docs
 ```mermaid
 classDiagram
 
-    class Area_Extraction {
-        type: GeomType = GeomType.Polygon
-        coordinates: list[list[list[Union[float, int]]]]
-        bbox: Optional[list[Union[float, int]]]
-        category: AreaType
-        text: Optional[str]
-        confidence: Optional[float]
-        model: Optional[str]
-        model_version: Optional[str]
+    class GeomType {
+        <<Enumeration>>
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
     }
 
     class AreaType {
@@ -90,15 +86,19 @@ classDiagram
         Correlation_Diagram: str = 'Correlation_Diagram'
     }
 
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
+    class Area_Extraction {
+        type: GeomType = GeomType.Polygon
+        coordinates: list[list[list[Union[float, int]]]]
+        bbox: Optional[list[Union[float, int]]]
+        category: AreaType
+        text: Optional[str]
+        confidence: Optional[float]
+        model: Optional[str]
+        model_version: Optional[str]
     }
 
-    Area_Extraction ..> AreaType
     Area_Extraction ..> GeomType
+    Area_Extraction ..> AreaType
 
 
 ```
@@ -119,6 +119,24 @@ classDiagram
         type: GeomType = GeomType.Point
     }
 
+    class GroundControlPoint {
+        gcp_id: str
+        map_geom: Geom_Point
+        px_geom: Pixel_Point
+        confidence: Optional[float]
+        model: str
+        model_version: str
+        crs: Optional[str]
+    }
+
+    class GeoreferenceResults {
+        cog_id: str
+        georeference_results: Optional[list[GeoreferenceResult]]
+        gcps: Optional[list[GroundControlPoint]]
+        system: str
+        system_version: str
+    }
+
     class Area_Extraction {
         type: GeomType = GeomType.Polygon
         coordinates: list[list[list[Union[float, int]]]]
@@ -130,10 +148,10 @@ classDiagram
         model_version: Optional[str]
     }
 
-    class Pixel_Point {
-        rows_from_top: Union[float, int]
-        columns_from_left: Union[float, int]
-        type: GeomType = GeomType.Point
+    class ProjectionResult {
+        crs: str
+        gcp_ids: list[str]
+        file_name: str
     }
 
     class GeoreferenceResult {
@@ -142,10 +160,10 @@ classDiagram
         projections: Optional[list[ProjectionResult]]
     }
 
-    class ProjectionResult {
-        crs: str
-        gcp_ids: list[str]
-        file_name: str
+    class Pixel_Point {
+        rows_from_top: Union[float, int]
+        columns_from_left: Union[float, int]
+        type: GeomType = GeomType.Point
     }
 
     class GeomType {
@@ -155,34 +173,16 @@ classDiagram
         Polygon: str = 'Polygon'
     }
 
-    class GeoreferenceResults {
-        cog_id: str
-        georeference_results: Optional[list[GeoreferenceResult]]
-        gcps: Optional[list[GroundControlPoint]]
-        system: str
-        system_version: str
-    }
-
-    class GroundControlPoint {
-        gcp_id: str
-        map_geom: Geom_Point
-        px_geom: Pixel_Point
-        confidence: Optional[float]
-        model: str
-        model_version: str
-        crs: Optional[str]
-    }
-
-    Area_Extraction ..> AreaType
     Area_Extraction ..> GeomType
+    Area_Extraction ..> AreaType
     Geom_Point ..> GeomType
     Pixel_Point ..> GeomType
     GroundControlPoint ..> Geom_Point
     GroundControlPoint ..> Pixel_Point
-    GeoreferenceResult ..> Area_Extraction
     GeoreferenceResult ..> ProjectionResult
-    GeoreferenceResults ..> GeoreferenceResult
+    GeoreferenceResult ..> Area_Extraction
     GeoreferenceResults ..> GroundControlPoint
+    GeoreferenceResults ..> GeoreferenceResult
 
 
 ```
@@ -213,10 +213,11 @@ classDiagram
         model_version: str
     }
 
-    class MapShapeTypes {
+    class MapColorSchemeTypes {
         <<Enumeration>>
-        rectangular: str = 'rectangular'
-        non_rectangular: str = 'non_rectangular'
+        full_color: str = 'full_color'
+        monochrome: str = 'monochrome'
+        grayscale: str = 'grayscale'
     }
 
     class CogMetaData {
@@ -227,15 +228,14 @@ classDiagram
         map_metadata: Optional[list[MapMetaData]]
     }
 
-    class MapColorSchemeTypes {
+    class MapShapeTypes {
         <<Enumeration>>
-        full_color: str = 'full_color'
-        monochrome: str = 'monochrome'
-        grayscale: str = 'grayscale'
+        rectangular: str = 'rectangular'
+        non_rectangular: str = 'non_rectangular'
     }
 
-    MapMetaData ..> MapShapeTypes
     MapMetaData ..> MapColorSchemeTypes
+    MapMetaData ..> MapShapeTypes
     CogMetaData ..> MapMetaData
 
 
@@ -251,14 +251,9 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class LineLegendAndFeaturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        name: Optional[str]
-        description: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        line_features: Optional[LineFeatureCollection]
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[Polygon]] = None
     }
 
     class Area_Extraction {
@@ -272,17 +267,33 @@ classDiagram
         model_version: Optional[str]
     }
 
+    class FeatureResults {
+        system: str
+        system_version: str
+        cog_id: str
+        line_feature_results: Optional[list[LineLegendAndFeaturesResult]] = None
+        point_feature_results: Optional[list[PointLegendAndFeaturesResult]] = None
+        polygon_features: Optional[list[PolygonMapUnit]] = None
+        cog_area_extractions: Optional[list[Area_Extraction]] = None
+        cog_metadata_extractions: Optional[list[CogMetaData]] = None
+    }
+
+    class LineLegendAndFeaturesResult {
+        id: str
+        crs: str
+        cdr_projection_id: Optional[str]
+        name: Optional[str]
+        description: Optional[str]
+        legend_bbox: Optional[list[Union[float, int]]]
+        line_features: Optional[LineFeatureCollection]
+    }
+
     class CogMetaData {
         cog_id: str
         system: str
         system_version: str
         multiple_maps: Optional[bool]
         map_metadata: Optional[list[MapMetaData]]
-    }
-
-    class PolygonMapUnit {
-        legend: Optional[PolygonLegend] = None
-        segmentation: Optional[list[PolygonSegmentation]] = None
     }
 
     class PointLegendAndFeaturesResult {
@@ -295,28 +306,17 @@ classDiagram
         point_features: Optional[list[PointFeatureCollection]]
     }
 
-    class FeatureResults {
-        system: str
-        system_version: str
-        cog_id: str
-        line_feature_results: Optional[list[LineLegendAndFeaturesResult]] = None
-        point_feature_results: Optional[list[PointLegendAndFeaturesResult]] = None
-        polygon_features: Optional[list[PolygonMapUnit]] = None
-        cog_area_extractions: Optional[list[Area_Extraction]] = None
-        cog_metadata_extractions: Optional[list[CogMetaData]] = None
-    }
-
-    Area_Extraction ..> AreaType
     Area_Extraction ..> GeomType
+    Area_Extraction ..> AreaType
     LineLegendAndFeaturesResult ..> LineFeatureCollection
     PointLegendAndFeaturesResult ..> PointFeatureCollection
-    PolygonMapUnit ..> PolygonSegmentation
+    PolygonMapUnit ..> Polygon
     PolygonMapUnit ..> PolygonLegend
     CogMetaData ..> MapMetaData
-    FeatureResults ..> LineLegendAndFeaturesResult
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> CogMetaData
     FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> Area_Extraction
+    FeatureResults ..> LineLegendAndFeaturesResult
+    FeatureResults ..> CogMetaData
     FeatureResults ..> PointLegendAndFeaturesResult
 
 
@@ -332,9 +332,37 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class GeomType {
+        <<Enumeration>>
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
+    }
+
     class PointFeatureCollection {
         type: GeoJsonType = GeoJsonType.FeatureCollection
         features: list[PointFeature]
+    }
+
+    class GeoJsonType {
+        <<Enumeration>>
+        Feature: str = 'Feature'
+        FeatureCollection: str = 'FeatureCollection'
+    }
+
+    class PointLegendAndFeaturesResult {
+        id: str
+        crs: str
+        cdr_projection_id: Optional[str]
+        name: Optional[str]
+        description: Optional[str]
+        legend_bbox: Optional[list[Union[float, int]]]
+        point_features: Optional[list[PointFeatureCollection]]
+    }
+
+    class Point {
+        coordinates: list[Union[float, int]]
+        type: GeomType = GeomType.Point
     }
 
     class PointFeature {
@@ -353,38 +381,10 @@ classDiagram
         dip_direction: Optional[int]
     }
 
-    class PointLegendAndFeaturesResult {
-        id: str
-        crs: str
-        cdr_projection_id: Optional[str]
-        name: Optional[str]
-        description: Optional[str]
-        legend_bbox: Optional[list[Union[float, int]]]
-        point_features: Optional[list[PointFeatureCollection]]
-    }
-
-    class Point {
-        coordinates: list[Union[float, int]]
-        type: GeomType = GeomType.Point
-    }
-
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
-    }
-
-    class GeoJsonType {
-        <<Enumeration>>
-        Feature: str = 'Feature'
-        FeatureCollection: str = 'FeatureCollection'
-    }
-
     Point ..> GeomType
-    PointFeature ..> PointProperties
     PointFeature ..> Point
     PointFeature ..> GeoJsonType
+    PointFeature ..> PointProperties
     PointFeatureCollection ..> PointFeature
     PointFeatureCollection ..> GeoJsonType
     PointLegendAndFeaturesResult ..> PointFeatureCollection
@@ -402,14 +402,10 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class LineFeatureCollection {
-        type: GeoJsonType = GeoJsonType.FeatureCollection
-        features: Optional[list[LineFeature]]
-    }
-
-    class Line {
-        coordinates: list[list[Union[float, int]]]
-        type: GeomType = GeomType.LineString
+    class GeoJsonType {
+        <<Enumeration>>
+        Feature: str = 'Feature'
+        FeatureCollection: str = 'FeatureCollection'
     }
 
     class DashType {
@@ -419,11 +415,17 @@ classDiagram
         dotted: str = 'dotted'
     }
 
-    class GeomType {
-        <<Enumeration>>
-        Point: str = 'Point'
-        LineString: str = 'LineString'
-        Polygon: str = 'Polygon'
+    class Line {
+        coordinates: list[list[Union[float, int]]]
+        type: GeomType = GeomType.LineString
+    }
+
+    class LineProperty {
+        model: Optional[str]
+        model_version: Optional[str]
+        confidence: Optional[float]
+        dash_pattern: Optional[DashType] = None
+        symbol: Optional[str]
     }
 
     class LineFeature {
@@ -443,24 +445,22 @@ classDiagram
         line_features: Optional[LineFeatureCollection]
     }
 
-    class LineProperty {
-        model: Optional[str]
-        model_version: Optional[str]
-        confidence: Optional[float]
-        dash_pattern: Optional[DashType] = None
-        symbol: Optional[str]
+    class GeomType {
+        <<Enumeration>>
+        Point: str = 'Point'
+        LineString: str = 'LineString'
+        Polygon: str = 'Polygon'
     }
 
-    class GeoJsonType {
-        <<Enumeration>>
-        Feature: str = 'Feature'
-        FeatureCollection: str = 'FeatureCollection'
+    class LineFeatureCollection {
+        type: GeoJsonType = GeoJsonType.FeatureCollection
+        features: Optional[list[LineFeature]]
     }
 
     Line ..> GeomType
     LineProperty ..> DashType
-    LineFeature ..> LineProperty
     LineFeature ..> Line
+    LineFeature ..> LineProperty
     LineFeature ..> GeoJsonType
     LineFeatureCollection ..> LineFeature
     LineFeatureCollection ..> GeoJsonType
@@ -479,14 +479,22 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class PolygonMapUnit {
-        legend: Optional[PolygonLegend] = None
-        segmentation: Optional[list[PolygonSegmentation]] = None
+    class Polygon {
+        provenance: ModelProvenance
+        crs: Optional[str] = None
+        cdr_projection_id: Optional[str] = None
+        geometry: list[list[Union[float, int]]]
     }
 
-    class PolygonSegmentation {
-        provenance: ModelProvenance
-        geometry: list[list[list[Union[float, int]]]]
+    class PolygonMapUnit {
+        legend: Optional[PolygonLegend] = None
+        segmentation: Optional[list[Polygon]] = None
+    }
+
+    class ModelProvenance {
+        model: Optional[str] = None
+        model_version: Optional[str] = None
+        confidence: Optional[float] = None
     }
 
     class PolygonLegend {
@@ -498,17 +506,19 @@ classDiagram
         color: Optional[str] = None
         pattern: Optional[str] = None
         overlay: Optional[bool] = None
+        age_text: Optional[str] = None
+        b_age: Optional[float] = None
+        b_interval: Optional[str] = None
+        lithology: Optional[str] = None
+        name: Optional[str] = None
+        t_age: Optional[float] = None
+        t_interval: Optional[str] = None
+        comments: Optional[str] = None
     }
 
-    class ModelProvenance {
-        model: Optional[str] = None
-        model_version: Optional[str] = None
-        confidence: Optional[float] = None
-    }
-
-    PolygonSegmentation ..> ModelProvenance
+    Polygon ..> ModelProvenance
     PolygonLegend ..> ModelProvenance
-    PolygonMapUnit ..> PolygonSegmentation
+    PolygonMapUnit ..> Polygon
     PolygonMapUnit ..> PolygonLegend
 
 
@@ -540,10 +550,11 @@ classDiagram
         model_version: str
     }
 
-    class MapShapeTypes {
+    class MapColorSchemeTypes {
         <<Enumeration>>
-        rectangular: str = 'rectangular'
-        non_rectangular: str = 'non_rectangular'
+        full_color: str = 'full_color'
+        monochrome: str = 'monochrome'
+        grayscale: str = 'grayscale'
     }
 
     class CogMetaData {
@@ -554,15 +565,14 @@ classDiagram
         map_metadata: Optional[list[MapMetaData]]
     }
 
-    class MapColorSchemeTypes {
+    class MapShapeTypes {
         <<Enumeration>>
-        full_color: str = 'full_color'
-        monochrome: str = 'monochrome'
-        grayscale: str = 'grayscale'
+        rectangular: str = 'rectangular'
+        non_rectangular: str = 'non_rectangular'
     }
 
-    MapMetaData ..> MapShapeTypes
     MapMetaData ..> MapColorSchemeTypes
+    MapMetaData ..> MapShapeTypes
     CogMetaData ..> MapMetaData
 
 
@@ -578,6 +588,20 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class DocumentExtraction {
+        id: UnionType[str, NoneType] = None
+        document_id: str = None
+        extraction_type: str
+        extraction_label: str
+        score: UnionType[float, NoneType] = None
+        bbox: UnionType[tuple[float, float, float, float], NoneType] = None
+        page_num: UnionType[int, NoneType] = None
+        external_link: UnionType[str, NoneType] = None
+        data: Optional[dict[]] = None
+        system: str
+        system_version: str
+    }
+
     class DocumentProvenance {
         external_system_name: str
         external_system_id: Optional[str] = ''
@@ -589,20 +613,6 @@ classDiagram
         is_open: bool = True
         provenance: Optional[DocumentProvenance] = None
         metadata: Optional[DocumentMetaData] = None
-        system: str
-        system_version: str
-    }
-
-    class DocumentExtraction {
-        id: UnionType[str, NoneType] = None
-        document_id: str = None
-        extraction_type: str
-        extraction_label: str
-        score: UnionType[float, NoneType] = None
-        bbox: UnionType[tuple[float, float, float, float], NoneType] = None
-        page_num: UnionType[int, NoneType] = None
-        external_link: UnionType[str, NoneType] = None
-        data: Optional[dict[]] = None
         system: str
         system_version: str
     }
@@ -630,10 +640,10 @@ classDiagram
         system_version: str
     }
 
-    UploadDocument ..> DocumentProvenance
     UploadDocument ..> DocumentMetaData
-    Document ..> DocumentProvenance
+    UploadDocument ..> DocumentProvenance
     Document ..> DocumentMetaData
+    Document ..> DocumentProvenance
 
 
 ```
@@ -648,6 +658,39 @@ classDiagram
 ```mermaid
 classDiagram
 
+    class MineralSite {
+        source_id: str
+        record_id: str
+        name: Optional[str]
+        mineral_inventory: list[MineralInventory]
+        location_info: LocationInfo
+        geology_info: Optional[GeologyInfo]
+        deposit_type_candidate: list[DepositTypeCandidate]
+    }
+
+    class MappableCriteria {
+        criteria: str
+        theoretical: Optional[str]
+        potential_dataset: Optional[list[EvidenceLayer]]
+        supporting_references: list[Reference]
+    }
+
+    class Ore {
+        ore_unit: str
+        ore_value: float
+    }
+
+    class Geometry {
+        <<Enumeration>>
+        Point: str = 'Point'
+        Polygon: str = 'Polygon'
+    }
+
+    class Grade {
+        grade_unit: str
+        grade_value: float
+    }
+
     class Commodity {
         name: str
     }
@@ -657,6 +700,26 @@ classDiagram
         normalized_uri: DepositType
         confidence: float
         source: str
+    }
+
+    class MineralSystem {
+        deposit_type: list[DepositType]
+        source: list[MappableCriteria]
+        pathway: list[MappableCriteria]
+        trap: Optional[list[MappableCriteria]]
+        preservation: Optional[list[MappableCriteria]]
+        energy: Optional[list[MappableCriteria]]
+        outflow: Optional[list[MappableCriteria]]
+    }
+
+    class EvidenceLayer {
+        name: str
+        relevance_score: float
+    }
+
+    class PageInfo {
+        page: int
+        bounding_box: Optional[BoundingBox]
     }
 
     class Document {
@@ -669,98 +732,6 @@ classDiagram
         metadata: Optional[DocumentMetaData] = None
         system: str
         system_version: str
-    }
-
-    class MineralSite {
-        source_id: str
-        record_id: str
-        name: Optional[str]
-        mineral_inventory: list[MineralInventory]
-        location_info: LocationInfo
-        geology_info: Optional[GeologyInfo]
-        deposit_type_candidate: list[DepositTypeCandidate]
-    }
-
-    class Geometry {
-        <<Enumeration>>
-        Point: str = 'Point'
-        Polygon: str = 'Polygon'
-    }
-
-    class DepositType {
-        name: str
-        environment: str
-        group: str
-    }
-
-    class MappableCriteria {
-        criteria: str
-        theoretical: Optional[str]
-        potential_dataset: Optional[list[EvidenceLayer]]
-        supporting_references: list[Reference]
-    }
-
-    class Grade {
-        grade_unit: str
-        grade_value: float
-    }
-
-    class LocationInfo {
-        location: Geometry
-        crs: str
-        country: Optional[str]
-        state_or_province: Optional[str]
-    }
-
-    class ResourceReserveCategory {
-        <<Enumeration>>
-        INFERRED: str = 'Inferred Mineral Resource'
-        INDICATED: str = 'Indicated Mineral Resource'
-        MEASURED: str = 'Measured Mineral Resource'
-        PROBABLE: str = 'Probable Mineral Reserve'
-        PROVEN: str = 'Proven Mineral Reserve'
-    }
-
-    class GeologyInfo {
-        age: Optional[str]
-        unit_name: Optional[str]
-        description: Optional[str]
-        lithology: Optional[list[str]]
-        process: Optional[list[str]]
-        environment: Optional[list[str]]
-        comments: Optional[str]
-    }
-
-    class PageInfo {
-        page: int
-        bounding_box: Optional[BoundingBox]
-    }
-
-    class BoundingBox {
-        x_min: float
-        x_max: float
-        y_min: float
-        y_max: float
-    }
-
-    class Reference {
-        document: Document
-        page_info: list[PageInfo]
-    }
-
-    class Ore {
-        ore_unit: str
-        ore_value: float
-    }
-
-    class MineralSystem {
-        deposit_type: list[DepositType]
-        source: list[MappableCriteria]
-        pathway: list[MappableCriteria]
-        trap: Optional[list[MappableCriteria]]
-        preservation: Optional[list[MappableCriteria]]
-        energy: Optional[list[MappableCriteria]]
-        outflow: Optional[list[MappableCriteria]]
     }
 
     class MineralInventory {
@@ -776,13 +747,52 @@ classDiagram
         zone: Optional[str]
     }
 
-    class EvidenceLayer {
-        name: str
-        relevance_score: float
+    class ResourceReserveCategory {
+        <<Enumeration>>
+        INFERRED: str = 'Inferred Mineral Resource'
+        INDICATED: str = 'Indicated Mineral Resource'
+        MEASURED: str = 'Measured Mineral Resource'
+        PROBABLE: str = 'Probable Mineral Reserve'
+        PROVEN: str = 'Proven Mineral Reserve'
     }
 
-    Document ..> DocumentProvenance
+    class BoundingBox {
+        x_min: float
+        x_max: float
+        y_min: float
+        y_max: float
+    }
+
+    class Reference {
+        document: Document
+        page_info: list[PageInfo]
+    }
+
+    class LocationInfo {
+        location: Geometry
+        crs: str
+        country: Optional[str]
+        state_or_province: Optional[str]
+    }
+
+    class DepositType {
+        name: str
+        environment: str
+        group: str
+    }
+
+    class GeologyInfo {
+        age: Optional[str]
+        unit_name: Optional[str]
+        description: Optional[str]
+        lithology: Optional[list[str]]
+        process: Optional[list[str]]
+        environment: Optional[list[str]]
+        comments: Optional[str]
+    }
+
     Document ..> DocumentMetaData
+    Document ..> DocumentProvenance
     DepositTypeCandidate ..> DepositType
     PageInfo ..> BoundingBox
     Reference ..> PageInfo
@@ -791,17 +801,17 @@ classDiagram
     MappableCriteria ..> EvidenceLayer
     MineralSystem ..> MappableCriteria
     MineralSystem ..> DepositType
-    MineralInventory ..> Commodity
-    MineralInventory ..> Ore
-    MineralInventory ..> Reference
-    MineralInventory ..> Grade
-    MineralInventory ..> ResourceReserveCategory
     MineralInventory ..> datetime
+    MineralInventory ..> Ore
+    MineralInventory ..> ResourceReserveCategory
+    MineralInventory ..> Grade
+    MineralInventory ..> Reference
+    MineralInventory ..> Commodity
     LocationInfo ..> Geometry
     MineralSite ..> DepositTypeCandidate
+    MineralSite ..> MineralInventory
     MineralSite ..> LocationInfo
     MineralSite ..> GeologyInfo
-    MineralSite ..> MineralInventory
 
 
 ```
@@ -824,6 +834,12 @@ classDiagram
         system_version: str
     }
 
+    class MapResults {
+        cog_id: str
+        georef_results: Optional[list[GeoreferenceResults]]
+        extraction_results: Optional[list[FeatureResults]]
+    }
+
     class FeatureResults {
         system: str
         system_version: str
@@ -835,19 +851,13 @@ classDiagram
         cog_metadata_extractions: Optional[list[CogMetaData]] = None
     }
 
-    class MapResults {
-        cog_id: str
-        georef_results: Optional[list[GeoreferenceResults]]
-        extraction_results: Optional[list[FeatureResults]]
-    }
-
-    FeatureResults ..> LineLegendAndFeaturesResult
-    FeatureResults ..> Area_Extraction
-    FeatureResults ..> CogMetaData
     FeatureResults ..> PolygonMapUnit
+    FeatureResults ..> Area_Extraction
+    FeatureResults ..> LineLegendAndFeaturesResult
+    FeatureResults ..> CogMetaData
     FeatureResults ..> PointLegendAndFeaturesResult
-    GeoreferenceResults ..> GeoreferenceResult
     GeoreferenceResults ..> GroundControlPoint
+    GeoreferenceResults ..> GeoreferenceResult
     MapResults ..> GeoreferenceResults
     MapResults ..> FeatureResults
 
@@ -864,18 +874,18 @@ classDiagram
 ```mermaid
 classDiagram
 
-    class MapProvenance {
-        system_name: str
-        id: str = None
-        url: str = None
-    }
-
     class Map {
         id: str
         provenance: Optional[list[MapProvenance]] = None
         is_open: bool
         system: str
         system_version: str
+    }
+
+    class MapProvenance {
+        system_name: str
+        id: str = None
+        url: str = None
     }
 
     Map ..> MapProvenance

--- a/cdr_schemas/common.py
+++ b/cdr_schemas/common.py
@@ -3,6 +3,9 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Constant for defining that a projection is in pixel coordinates
+CRITICALMAAS_PIXEL = "pixel"
+
 
 class GeomType(str, Enum):
     Point = "Point"

--- a/cdr_schemas/common.py
+++ b/cdr_schemas/common.py
@@ -1,12 +1,24 @@
 from enum import Enum
-
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, Field
 
 class GeomType(str, Enum):
     Point = "Point"
     LineString = "LineString"
     Polygon = "Polygon"
 
+# class GeoJsonType(str, Enum):
+#     Feature = "Feature"
+#     FeatureCollection = "FeatureCollection"
 
-class GeoJsonType(str, Enum):
-    Feature = "Feature"
-    FeatureCollection = "FeatureCollection"
+class ModelProvenance(BaseModel):
+    model: Optional[str] = Field(
+        default=None,
+        description="Name of the model used to generate this data")
+    model_version: Optional[str] = Field(
+        default=None,
+        description="Version of the model used to generate this data")
+    model_config = ConfigDict(protected_namespaces=())
+    confidence: Optional[float] = Field(
+        default=None,
+        description="The prediction confidence of the model")

--- a/cdr_schemas/common.py
+++ b/cdr_schemas/common.py
@@ -7,9 +7,9 @@ class GeomType(str, Enum):
     LineString = "LineString"
     Polygon = "Polygon"
 
-# class GeoJsonType(str, Enum):
-#     Feature = "Feature"
-#     FeatureCollection = "FeatureCollection"
+class GeoJsonType(str, Enum):
+    Feature = "Feature"
+    FeatureCollection = "FeatureCollection"
 
 class ModelProvenance(BaseModel):
     model: Optional[str] = Field(

--- a/cdr_schemas/common.py
+++ b/cdr_schemas/common.py
@@ -1,24 +1,28 @@
 from enum import Enum
 from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
+
 
 class GeomType(str, Enum):
     Point = "Point"
     LineString = "LineString"
     Polygon = "Polygon"
 
+
 class GeoJsonType(str, Enum):
     Feature = "Feature"
     FeatureCollection = "FeatureCollection"
 
+
 class ModelProvenance(BaseModel):
     model: Optional[str] = Field(
-        default=None,
-        description="Name of the model used to generate this data")
+        default=None, description="Name of the model used to generate this data"
+    )
     model_version: Optional[str] = Field(
-        default=None,
-        description="Version of the model used to generate this data")
+        default=None, description="Version of the model used to generate this data"
+    )
     model_config = ConfigDict(protected_namespaces=())
     confidence: Optional[float] = Field(
-        default=None,
-        description="The prediction confidence of the model")
+        default=None, description="The prediction confidence of the model"
+    )

--- a/cdr_schemas/feature_results.py
+++ b/cdr_schemas/feature_results.py
@@ -8,33 +8,35 @@ from cdr_schemas.features.point_features import PointLegendAndFeaturesResult
 from cdr_schemas.features.polygon_features import PolygonMapUnit
 from cdr_schemas.metadata import CogMetaData
 
+
 class FeatureResults(BaseModel):
     """
     Feature Extraction Results.
     """
 
-    system: str = Field(
-        description="The name of the system used to generate results.")
+    system: str = Field(description="The name of the system used to generate results.")
     system_version: str = Field(
-        description="The version of the system used to generate results.")
-    cog_id: str = Field(
-        description="Cog id.")
+        description="The version of the system used to generate results."
+    )
+    cog_id: str = Field(description="Cog id.")
     line_feature_results: Optional[List[LineLegendAndFeaturesResult]] = Field(
         default=None,
-        description="""A list of legend extractions with associated line 
-                    feature results.""")
+        description="""A list of legend extractions with associated line
+                    feature results.""",
+    )
     point_feature_results: Optional[List[PointLegendAndFeaturesResult]] = Field(
         default=None,
-        description="""A list of legend extractions with associated point 
-                    feature results.""")
+        description="""A list of legend extractions with associated point
+                    feature results.""",
+    )
     polygon_features: Optional[List[PolygonMapUnit]] = Field(
-        default=None,
-        description="""A list of polygon map unit extractions.""")
+        default=None, description="""A list of polygon map unit extractions."""
+    )
     cog_area_extractions: Optional[List[Area_Extraction]] = Field(
         default=None,
-        description="""Higher level extraction pulled off a cog - legend area, 
-                    map area, ocr text area, etc.""")
+        description="""Higher level extraction pulled off a cog - legend area,
+                    map area, ocr text area, etc.""",
+    )
     cog_metadata_extractions: Optional[List[CogMetaData]] = Field(
-        default=None,
-        description="Metadata extractions pulled off a cog.")
-    
+        default=None, description="Metadata extractions pulled off a cog."
+    )

--- a/cdr_schemas/feature_results.py
+++ b/cdr_schemas/feature_results.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 from cdr_schemas.area_extraction import Area_Extraction
 from cdr_schemas.features.line_features import LineLegendAndFeaturesResult
 from cdr_schemas.features.point_features import PointLegendAndFeaturesResult
-from cdr_schemas.features.polygon_features import PolygonLegendAndFeatureResult
+from cdr_schemas.features.polygon_features import PolygonMapUnit
 from cdr_schemas.metadata import CogMetaData
 
 class FeatureResults(BaseModel):
@@ -27,10 +27,9 @@ class FeatureResults(BaseModel):
         default=None,
         description="""A list of legend extractions with associated point 
                     feature results.""")
-    polygon_feature_results: Optional[List[PolygonLegendAndFeatureResult]] = Field(
+    polygon_features: Optional[List[PolygonMapUnit]] = Field(
         default=None,
-        description="""A list of legend extractions with associated polygon 
-                    feature results.""")
+        description="""A list of polygon map unit extractions.""")
     cog_area_extractions: Optional[List[Area_Extraction]] = Field(
         default=None,
         description="""Higher level extraction pulled off a cog - legend area, 

--- a/cdr_schemas/feature_results.py
+++ b/cdr_schemas/feature_results.py
@@ -5,60 +5,37 @@ from pydantic import BaseModel, Field
 from cdr_schemas.area_extraction import Area_Extraction
 from cdr_schemas.features.line_features import LineLegendAndFeaturesResult
 from cdr_schemas.features.point_features import PointLegendAndFeaturesResult
-from cdr_schemas.features.polygon_features import PolygonLegendAndFeauturesResult
+from cdr_schemas.features.polygon_features import PolygonLegendAndFeatureResult
 from cdr_schemas.metadata import CogMetaData
-
 
 class FeatureResults(BaseModel):
     """
     Feature Extraction Results.
     """
 
-    cog_id: str = Field(
-        ...,
-        description="""
-            Cog id.
-        """,
-    )
-    line_feature_results: Optional[List[LineLegendAndFeaturesResult]] = Field(
-        ...,
-        description="""
-            A list of legend extractions with associated line feature results.
-        """,
-    )
-    point_feature_results: Optional[List[PointLegendAndFeaturesResult]] = Field(
-        ...,
-        description="""
-            A list of legend extractions with associated point feature results.
-        """,
-    )
-    polygon_feature_results: Optional[List[PolygonLegendAndFeauturesResult]] = Field(
-        ...,
-        description="""
-            A list of legend extractions with associated polygon feature results.
-        """,
-    )
-    cog_area_extractions: Optional[List[Area_Extraction]] = Field(
-        ...,
-        description="""
-            Higher level extraction pulled off a cog - legend area, map area, ocr text area, etc.
-        """,
-    )
-    cog_metadata_extractions: Optional[List[CogMetaData]] = Field(
-        ...,
-        description="""
-            Metadata extractions pulled off a cog.
-        """,
-    )
     system: str = Field(
-        ...,
-        description="""
-            The name of the system used.
-        """,
-    )
+        description="The name of the system used to generate results.")
     system_version: str = Field(
-        ...,
-        description="""
-            The version of the system used.
-        """,
-    )
+        description="The version of the system used to generate results.")
+    cog_id: str = Field(
+        description="Cog id.")
+    line_feature_results: Optional[List[LineLegendAndFeaturesResult]] = Field(
+        default=None,
+        description="""A list of legend extractions with associated line 
+                    feature results.""")
+    point_feature_results: Optional[List[PointLegendAndFeaturesResult]] = Field(
+        default=None,
+        description="""A list of legend extractions with associated point 
+                    feature results.""")
+    polygon_feature_results: Optional[List[PolygonLegendAndFeatureResult]] = Field(
+        default=None,
+        description="""A list of legend extractions with associated polygon 
+                    feature results.""")
+    cog_area_extractions: Optional[List[Area_Extraction]] = Field(
+        default=None,
+        description="""Higher level extraction pulled off a cog - legend area, 
+                    map area, ocr text area, etc.""")
+    cog_metadata_extractions: Optional[List[CogMetaData]] = Field(
+        default=None,
+        description="Metadata extractions pulled off a cog.")
+    

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -73,11 +73,11 @@ class PolygonMapUnit(BaseModel):
     Polygon map unit metadata along with associated polygon segmentation found.
     """
 
-    legend = Optional[PolygonLegend] = Field(
+    legend: Optional[PolygonLegend] = Field(
         default=None,
         description="Legend information for polygon map unit."
     )
-    segmentation = Optional[List[PolygonSegmentation]] = Field(
+    segmentation: Optional[List[PolygonSegmentation]] = Field(
         default=None,
         description="Polygon Segmentations for polygon map unit item.")
     

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
-from pydantic import BaseModel, ConfigDict, Field
-from cdr_schemas.common import ModelProvenance, GeomType
+from pydantic import BaseModel, Field
+from cdr_schemas.common import ModelProvenance
 
 class PolygonSegmentation(BaseModel):
     """
@@ -13,10 +13,12 @@ class PolygonSegmentation(BaseModel):
 
     # Data
     geometry: List[List[List[Union[float, int]]]]
-    geom_type: GeomType = GeomType.Polygon
-    id: str = Field(
-        description="""Each polygon geometry has a unique id. The ids are used 
-                    to link the polygon geometries is px-coord and geo-coord.""")   
+
+    # Why are we returning internal ids for polygons? also when would this ever not be GeomType.Polygon, this is a polygon segmentation
+    # geom_type: GeomType = GeomType.Polygon
+    # id: str = Field(
+    #     description="""Each polygon geometry has a unique id. The ids are used 
+    #                 to link the polygon geometries is px-coord and geo-coord.""")   
 
 class PolygonLegend(BaseModel):
     """

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -5,16 +5,30 @@ from pydantic import BaseModel, Field
 from cdr_schemas.common import ModelProvenance
 
 
-class PolygonSegmentation(BaseModel):
+class Polygon(BaseModel):
     """
-    Segmentation of a polygon map unit.
+    Individual contiguous polygon of a segmentation for a polygon map unit.
     """
 
     # Provenance
     provenance: ModelProvenance = Field(description="Where the data orginated from.")
 
     # Data
-    geometry: List[List[List[Union[float, int]]]]
+    crs: Optional[str] = Field(
+        default=None,
+        # default=CRITICALMASS:pixel, # TODO Define CRITICALMASS:pixel somewhere before it can be the default
+        description="""What projection the geometry of the segmentation are in,
+                    Default is CRITICALMASS:pixel which specifies pixel coordinates.
+                    Possible values are {CRITICALMAAS:pixel, EPSG:*}""",
+    )
+    cdr_projection_id: Optional[str] = Field(
+        default=None,
+        description="""If non-pixel coordinates are used the cdr projection id of the
+                    georeference that was used to create them is required.""",
+    )
+    geometry: List[List[Union[float, int]]] = Field(
+        description="The coordinates of polygon."
+    )
 
     # Why are we returning internal ids for polygons? also when would this ever not be GeomType.Polygon, this is a polygon segmentation
     # geom_type: GeomType = GeomType.Polygon
@@ -53,23 +67,22 @@ class PolygonLegend(BaseModel):
         description="Wheather or not the map unit can be overlayed on other map units",
     )
 
-    # What is this?
+    # TODO Someone else will need to add descriptions to these fields as I don't know what they are
+    age_text: Optional[str] = None
+    b_age: Optional[float] = None
+    b_interval: Optional[str] = None
+    lithology: Optional[str] = None
+    name: Optional[str] = None
+    t_age: Optional[float] = None
+    t_interval: Optional[str] = None
+    comments: Optional[str] = None
+
+    # Agreed on Apr 15th call that this field can be removed
     # category: Optional[str] = Field(
     #     default=None,
-    #     description="TODO - what is this?")
-
-    # I would remove these as i don't think we have any system that fills them in
-    # age_text: Optional[str] = None
-    # b_age: Optional[float] = None
-    # b_interval: Optional[str] = None
-    # lithology: Optional[str] = None
-    # name: Optional[str] = None
-    # t_age: Optional[float] = None
-    # t_interval: Optional[str] = None
-    # comments: Optional[str] = None
+    #     description="what is this?")
 
 
-# Is object that can be sent to the CDR on its own/ is this a _Result??? or is it just a subfield of feature_results
 class PolygonMapUnit(BaseModel):
     """
     Polygon map unit metadata along with associated polygon segmentation found.
@@ -78,18 +91,10 @@ class PolygonMapUnit(BaseModel):
     legend: Optional[PolygonLegend] = Field(
         default=None, description="Legend information for polygon map unit."
     )
-    segmentation: Optional[List[PolygonSegmentation]] = Field(
-        default=None, description="Polygon Segmentations for polygon map unit item."
+    segmentation: Optional[List[Polygon]] = Field(
+        default=None,
+        description="List of polygons that make up the segmentation for the polygon map unit.",
     )
 
-    # What is this
+    # What is this?
     # id: str = Field(description="your internal id")
-
-    # Why do we have any link to georeferencing in the segmentation result. One of the big reasons to change to this format
-    # was to decouple georeferecing from segmentation. All results should be in image coords space.
-    # crs: Optional[str] = Field(
-    #     default=None,
-    #     description="values={CRITICALMAAS:pixel, EPSG:*}")
-    # cdr_projection_id: Optional[str] = Field(
-    #     default=None,
-    #     description="A cdr projection id used to georeference the features") ### TODO Could use some more explanation

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -1,7 +1,5 @@
 from typing import List, Optional, Union
-
 from pydantic import BaseModel, ConfigDict, Field
-
 from cdr_schemas.common import GeoJsonType, GeomType
 
 
@@ -19,12 +17,16 @@ class PolygonProperty(BaseModel):
     Properties of the polygon.
     """
 
-    model: Optional[str] = Field(description="model name used for extraction")
+    model: Optional[str] = Field(
+        default=None,
+        description="Name of the model used for extraction")
     model_version: Optional[str] = Field(
-        description="model version used for extraction"
+        default=None,
+        description="Version of the model used for extraction"
     )
     confidence: Optional[float] = Field(
-        description="The prediction probability from the ML model"
+        default=None,
+        description="The prediction confidence of the model"
     )
 
     model_config = ConfigDict(protected_namespaces=())
@@ -50,7 +52,7 @@ class PolygonFeatureCollection(BaseModel):
     """
 
     type: GeoJsonType = GeoJsonType.FeatureCollection
-    features: Optional[List[PolygonFeature]]
+    features: Optional[List[PolygonFeature]] = None
 
 
 class MapUnit(BaseModel):
@@ -58,36 +60,57 @@ class MapUnit(BaseModel):
     Map unit information for legend item.
     """
 
-    age_text: Optional[str]
-    b_age: Optional[float]
-    b_interval: Optional[str]
-    lithology: Optional[str]
-    name: Optional[str]
-    t_age: Optional[float]
-    t_interval: Optional[str]
-    comments: Optional[str]
+    # TODO Add details on what these fields are / are we keeping them
+    age_text: Optional[str] = None
+    b_age: Optional[float] = None
+    b_interval: Optional[str] = None
+    lithology: Optional[str] = None
+    name: Optional[str] = None
+    t_age: Optional[float] = None
+    t_interval: Optional[str] = None
+    comments: Optional[str] = None
 
 
-class PolygonLegendAndFeauturesResult(BaseModel):
+class PolygonLegendAndFeatureResult(BaseModel):
     """
-    Polygon legend item metadata along with associated polygon features found.
+    Polygon map unit metadata along with associated polygon segmentation found.
     """
 
     id: str = Field(description="your internal id")
-    crs: str = Field(description="values={CRITICALMAAS:pixel, EPSG:*}")
+
+    # Legend Fields
+    label: Optional[str] = Field(
+        default=None,
+        description="Label of the map unit")
+    abbreviation: Optional[str] = Field(
+        default=None,
+        description="Abbreviation of the map unit label.")
+    description: Optional[str] = Field(
+        default=None,
+        description="Description of the map unit")
+    legend_bbox: Optional[List[List[Union[float, int]]]] = Field(
+        default=None,
+        description="The bounding box of the map units label.")
+    color: Optional[str] = Field(
+        default=None,
+        description="The color of the map unit")
+    pattern: Optional[str] = Field(
+        default=None,
+        description="The pattern of the map unit")
+    category: Optional[str] = Field(
+        default=None,
+        description="TODO - what is this?") ### TODO
+    map_unit: Optional[MapUnit] = Field(
+        default=None,
+        description="Human annotated information on the mab unit")
+    
+    # Segmentation Fields
+    crs: Optional[str] = Field(
+        default=None, 
+        description="values={CRITICALMAAS:pixel, EPSG:*}")
     cdr_projection_id: Optional[str] = Field(
-        description="""
-                        A cdr projection id used to georeference the features
-                    """
-    )
-    map_unit: Optional[MapUnit]
-    abbreviation: Optional[str]
-    legend_bbox: Optional[List[Union[float, int]]] = Field(
-        description="""The extacted bounding box of the legend item.
-        Column value from left, row value from bottom."""
-    )
-    category: Optional[str]
-    color: Optional[str]
-    description: Optional[str]
-    pattern: Optional[str]
-    polygon_features: Optional[PolygonFeatureCollection]
+        default=None,
+        description="A cdr projection id used to georeference the features") ### TODO Could use some more explanation
+    polygon_features: Optional[PolygonFeatureCollection] = Field(
+        default=None,
+        description="All polygon features for legend item.")

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -1,6 +1,9 @@
 from typing import List, Optional, Union
+
 from pydantic import BaseModel, Field
+
 from cdr_schemas.common import ModelProvenance
+
 
 class PolygonSegmentation(BaseModel):
     """
@@ -8,8 +11,7 @@ class PolygonSegmentation(BaseModel):
     """
 
     # Provenance
-    provenance: ModelProvenance = Field(
-        description="Where the data orginated from.")
+    provenance: ModelProvenance = Field(description="Where the data orginated from.")
 
     # Data
     geometry: List[List[List[Union[float, int]]]]
@@ -17,46 +19,46 @@ class PolygonSegmentation(BaseModel):
     # Why are we returning internal ids for polygons? also when would this ever not be GeomType.Polygon, this is a polygon segmentation
     # geom_type: GeomType = GeomType.Polygon
     # id: str = Field(
-    #     description="""Each polygon geometry has a unique id. The ids are used 
-    #                 to link the polygon geometries is px-coord and geo-coord.""")   
+    #     description="""Each polygon geometry has a unique id. The ids are used
+    #                 to link the polygon geometries is px-coord and geo-coord.""")
+
 
 class PolygonLegend(BaseModel):
     """
     Legend information for a polygon map unit.
     """
+
     # Provenance
-    provenance: ModelProvenance = Field(
-        description="Where the data orginated from.")
+    provenance: ModelProvenance = Field(description="Where the data orginated from.")
 
     # Data
-    label: Optional[str] = Field(
-        default=None,
-        description="Label of the map unit")
+    label: Optional[str] = Field(default=None, description="Label of the map unit")
     abbreviation: Optional[str] = Field(
-        default=None,
-        description="Abbreviation of the map unit label.")
+        default=None, description="Abbreviation of the map unit label."
+    )
     description: Optional[str] = Field(
-        default=None,
-        description="Description of the map unit")
+        default=None, description="Description of the map unit"
+    )
     legend_bbox: Optional[List[List[Union[float, int]]]] = Field(
-        default=None,
-        description="The bounding box of the map units label.")
+        default=None, description="The bounding box of the map units label."
+    )
     color: Optional[str] = Field(
-        default=None,
-        description="The color of the map unit's legend")
+        default=None, description="The color of the map unit's legend"
+    )
     pattern: Optional[str] = Field(
-        default=None,
-        description="The pattern of the map unit's legend")
+        default=None, description="The pattern of the map unit's legend"
+    )
     overlay: Optional[bool] = Field(
         default=None,
-        description="Wheather or not the map unit can be overlayed on other map units")
-    
+        description="Wheather or not the map unit can be overlayed on other map units",
+    )
+
     # What is this?
     # category: Optional[str] = Field(
     #     default=None,
     #     description="TODO - what is this?")
 
-    # I would remove these as i don't think we have any system that fills them in 
+    # I would remove these as i don't think we have any system that fills them in
     # age_text: Optional[str] = None
     # b_age: Optional[float] = None
     # b_interval: Optional[str] = None
@@ -74,20 +76,19 @@ class PolygonMapUnit(BaseModel):
     """
 
     legend: Optional[PolygonLegend] = Field(
-        default=None,
-        description="Legend information for polygon map unit."
+        default=None, description="Legend information for polygon map unit."
     )
     segmentation: Optional[List[PolygonSegmentation]] = Field(
-        default=None,
-        description="Polygon Segmentations for polygon map unit item.")
-    
-    # What is this 
+        default=None, description="Polygon Segmentations for polygon map unit item."
+    )
+
+    # What is this
     # id: str = Field(description="your internal id")
 
     # Why do we have any link to georeferencing in the segmentation result. One of the big reasons to change to this format
     # was to decouple georeferecing from segmentation. All results should be in image coords space.
     # crs: Optional[str] = Field(
-    #     default=None, 
+    #     default=None,
     #     description="values={CRITICALMAAS:pixel, EPSG:*}")
     # cdr_projection_id: Optional[str] = Field(
     #     default=None,

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -1,84 +1,32 @@
 from typing import List, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
-from cdr_schemas.common import GeoJsonType, GeomType
+from cdr_schemas.common import ModelProvenance, GeomType
 
-
-class Polygon(BaseModel):
-    """
-    coordinates in line are  (column from left, row from bottom).
-    """
-
-    coordinates: List[List[List[Union[float, int]]]]
-    type: GeomType = GeomType.Polygon
-
-
-class PolygonProperty(BaseModel):
-    """
-    Properties of the polygon.
-    """
-
-    model: Optional[str] = Field(
-        default=None,
-        description="Name of the model used for extraction")
-    model_version: Optional[str] = Field(
-        default=None,
-        description="Version of the model used for extraction"
-    )
-    confidence: Optional[float] = Field(
-        default=None,
-        description="The prediction confidence of the model"
-    )
-
-    model_config = ConfigDict(protected_namespaces=())
-
-
-class PolygonFeature(BaseModel):
+class PolygonSegmentation(BaseModel):
     """
     Polygon feature.
     """
 
-    type: GeoJsonType = GeoJsonType.Feature
+    # Provenance
+    provenance: ModelProvenance = Field(
+        description="Where the data orginated from.")
+
+    # Data
+    geometry: List[List[List[Union[float, int]]]]
+    geom_type: GeomType = GeomType.Polygon
     id: str = Field(
-        description="""Each polygon geometry has a unique id.
-                The ids are used to link the polygon geometries is px-coord and geo-coord."""
-    )
-    geometry: Polygon
-    properties: PolygonProperty
+        description="""Each polygon geometry has a unique id. The ids are used 
+                    to link the polygon geometries is px-coord and geo-coord.""")   
 
-
-class PolygonFeatureCollection(BaseModel):
+class PolygonLegend(BaseModel):
     """
-    All polygon features for legend item.
+    Legend information for a polygon map unit.
     """
+    # Provenance
+    provenance: ModelProvenance = Field(
+        description="Where the data orginated from.")
 
-    type: GeoJsonType = GeoJsonType.FeatureCollection
-    features: Optional[List[PolygonFeature]] = None
-
-
-class MapUnit(BaseModel):
-    """
-    Map unit information for legend item.
-    """
-
-    # TODO Add details on what these fields are / are we keeping them
-    age_text: Optional[str] = None
-    b_age: Optional[float] = None
-    b_interval: Optional[str] = None
-    lithology: Optional[str] = None
-    name: Optional[str] = None
-    t_age: Optional[float] = None
-    t_interval: Optional[str] = None
-    comments: Optional[str] = None
-
-
-class PolygonLegendAndFeatureResult(BaseModel):
-    """
-    Polygon map unit metadata along with associated polygon segmentation found.
-    """
-
-    id: str = Field(description="your internal id")
-
-    # Legend Fields
+    # Data
     label: Optional[str] = Field(
         default=None,
         description="Label of the map unit")
@@ -93,24 +41,49 @@ class PolygonLegendAndFeatureResult(BaseModel):
         description="The bounding box of the map units label.")
     color: Optional[str] = Field(
         default=None,
-        description="The color of the map unit")
+        description="The color of the map unit's legend")
     pattern: Optional[str] = Field(
         default=None,
-        description="The pattern of the map unit")
-    category: Optional[str] = Field(
+        description="The pattern of the map unit's legend")
+    overlay: Optional[bool] = Field(
         default=None,
-        description="TODO - what is this?") ### TODO
-    map_unit: Optional[MapUnit] = Field(
-        default=None,
-        description="Human annotated information on the mab unit")
+        description="Wheather or not the map unit can be overlayed on other map units")
     
-    # Segmentation Fields
-    crs: Optional[str] = Field(
-        default=None, 
-        description="values={CRITICALMAAS:pixel, EPSG:*}")
-    cdr_projection_id: Optional[str] = Field(
-        default=None,
-        description="A cdr projection id used to georeference the features") ### TODO Could use some more explanation
-    polygon_features: Optional[PolygonFeatureCollection] = Field(
+    # What is this?
+    # category: Optional[str] = Field(
+    #     default=None,
+    #     description="TODO - what is this?")
+
+    # I would remove these as i don't think we have any system that fills them in 
+    # age_text: Optional[str] = None
+    # b_age: Optional[float] = None
+    # b_interval: Optional[str] = None
+    # lithology: Optional[str] = None
+    # name: Optional[str] = None
+    # t_age: Optional[float] = None
+    # t_interval: Optional[str] = None
+    # comments: Optional[str] = None
+
+
+# Is object that can be sent to the CDR on its own/ is this a _Result??? or is it just a subfield of feature_results
+class PolygonMapUnit(BaseModel):
+    """
+    Polygon map unit metadata along with associated polygon segmentation found.
+    """
+
+    legend = PolygonLegend
+    segmentation = Optional[List[PolygonSegmentation]] = Field(
         default=None,
         description="All polygon features for legend item.")
+    
+    # What is this 
+    # id: str = Field(description="your internal id")
+
+    # Why do we have any link to georeferencing in the segmentation result. One of the big reasons to change to this format
+    # was to decouple georeferecing from segmentation. All results should be in image coords space.
+    # crs: Optional[str] = Field(
+    #     default=None, 
+    #     description="values={CRITICALMAAS:pixel, EPSG:*}")
+    # cdr_projection_id: Optional[str] = Field(
+    #     default=None,
+    #     description="A cdr projection id used to georeference the features") ### TODO Could use some more explanation

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -26,7 +26,8 @@ class Polygon(BaseModel):
                     georeference that was used to create them is required.""",
     )
     geometry: List[List[Union[float, int]]] = Field(
-        description="The coordinates of polygon."
+        description="""The coordinates of polygon. Format is expected to be [x,y]
+                    coordinate pairs where the top left is the origin (0,0)."""
     )
 
     # Why are we returning internal ids for polygons? also when would this ever not be GeomType.Polygon, this is a polygon segmentation
@@ -54,11 +55,15 @@ class PolygonLegend(BaseModel):
     )
     legend_bbox: Optional[List[Union[float, int]]] = Field(
         default=None,
-        description="The rough 2 point bounding box of the map units label.",
+        description="""The rough 2 point bounding box of the map units label.
+                    Format is expected to be [x1,y1,x2,y2] where the top left
+                    is the origin (0,0).""",
     )
     legend_contour: Optional[List[List[Union[float, int]]]] = Field(
         default=None,
-        description="The more precise polygon bounding box of the map units label.",
+        description="""The more precise polygon bounding box of the map units
+                    label. Format is expected to be [x,y] coordinate pairs
+                    where the top left is the origin (0,0).""",
     )
     color: Optional[str] = Field(
         default=None, description="The color of the map unit's legend"

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from cdr_schemas.common import ModelProvenance
+from cdr_schemas.common import CRITICALMAAS_PIXEL, ModelProvenance
 
 
 class Polygon(BaseModel):
@@ -11,14 +11,13 @@ class Polygon(BaseModel):
     """
 
     # Provenance
-    provenance: ModelProvenance = Field(description="Where the data orginated from.")
+    provenance: ModelProvenance = Field(description="Where the data originated from.")
 
     # Data
     crs: Optional[str] = Field(
-        default=None,
-        # default=CRITICALMASS:pixel, # TODO Define CRITICALMASS:pixel somewhere before it can be the default
+        default=CRITICALMAAS_PIXEL,
         description="""What projection the geometry of the segmentation are in,
-                    Default is CRITICALMASS:pixel which specifies pixel coordinates.
+                    Default is CRITICALMAAS_PIXEL which specifies pixel coordinates.
                     Possible values are {CRITICALMAAS:pixel, EPSG:*}""",
     )
     cdr_projection_id: Optional[str] = Field(
@@ -43,7 +42,7 @@ class PolygonLegend(BaseModel):
     """
 
     # Provenance
-    provenance: ModelProvenance = Field(description="Where the data orginated from.")
+    provenance: ModelProvenance = Field(description="Where the data originated from.")
 
     # Data
     label: Optional[str] = Field(default=None, description="Label of the map unit")
@@ -53,8 +52,13 @@ class PolygonLegend(BaseModel):
     description: Optional[str] = Field(
         default=None, description="Description of the map unit"
     )
-    legend_bbox: Optional[List[List[Union[float, int]]]] = Field(
-        default=None, description="The bounding box of the map units label."
+    legend_bbox: Optional[List[Union[float, int]]] = Field(
+        default=None,
+        description="The rough 2 point bounding box of the map units label.",
+    )
+    legend_contour: Optional[List[List[Union[float, int]]]] = Field(
+        default=None,
+        description="The more precise polygon bounding box of the map units label.",
     )
     color: Optional[str] = Field(
         default=None, description="The color of the map unit's legend"
@@ -67,7 +71,7 @@ class PolygonLegend(BaseModel):
         description="Wheather or not the map unit can be overlayed on other map units",
     )
 
-    # TODO Someone else will need to add descriptions to these fields as I don't know what they are
+    # TODO Someone else will need to add full descriptions to these fields
     age_text: Optional[str] = None
     b_age: Optional[float] = None
     b_interval: Optional[str] = None

--- a/cdr_schemas/features/polygon_features.py
+++ b/cdr_schemas/features/polygon_features.py
@@ -4,7 +4,7 @@ from cdr_schemas.common import ModelProvenance
 
 class PolygonSegmentation(BaseModel):
     """
-    Polygon feature.
+    Segmentation of a polygon map unit.
     """
 
     # Provenance
@@ -73,10 +73,13 @@ class PolygonMapUnit(BaseModel):
     Polygon map unit metadata along with associated polygon segmentation found.
     """
 
-    legend = PolygonLegend
+    legend = Optional[PolygonLegend] = Field(
+        default=None,
+        description="Legend information for polygon map unit."
+    )
     segmentation = Optional[List[PolygonSegmentation]] = Field(
         default=None,
-        description="All polygon features for legend item.")
+        description="Polygon Segmentations for polygon map unit item.")
     
     # What is this 
     # id: str = Field(description="your internal id")


### PR DESCRIPTION
This PR is on top of the first pull request that contained bug fixes (#23). These are my suggestions for improving the usability of the polygon feature schema. Notes on changes are as follows:

- All of the polygon map unit metadata fields have been moved into a single class PolygonLegend.
- The polygon segmentation data has been condensed into a single class PolygonSegmentation.
- PolygonLegendAndFeatureResult has been renamed to PolygonMapUnit and now contains a PolygonLegend and a List of PolygonSegmentations.
- The Provence of a result is defined by ModelProvenance which is now tied in at PolygonLegend and PolygonSegmentation as opposed to before when it was at an individual polygon level and not at all for legend data.
- Removed Georeferencing data from polygon data.  One of the big reasons to change to this format was to decouple georeferencing from segmentation. All results should be in image coords space and independent of any georeferencing.
- Removed the old MapUnit Fields. I don't believe that any group produces that information and don't even think that a lot of that information is even contained in the map.
- Removed internal ids from sub-fields.

These are the changes I would like to discuss on Monday. I will also note that I have only made changed to polygon features. If the changes are accepted there can discuss following a consistent format in the line and point results.