### PR TITLE
Creation date field for CreateCriticalMineralAssessment schema

### DIFF
--- a/cdr_schemas/prospectivity_input.py
+++ b/cdr_schemas/prospectivity_input.py
@@ -90,6 +90,7 @@ class CreateCriticalMineralAssessment(BaseModel):
     resolution: List[Union[float, int]]
     mineral: str
     description: str
+    creation_date: str
 
 
 TranformMethods = List[Union[TransformMethod, Impute, ScalingType]]


### PR DESCRIPTION
Adds a creation date string field to the CreateCriticalMineralAssessment schema. This will be useful for tracking and sorting created CMAs.